### PR TITLE
sqlite: allow to use drop_constraint, drop_column and create_constraint

### DIFF
--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -42,37 +42,9 @@ class SQLiteImpl(DefaultImpl):
 
     def drop_constraint(self, const):
         if const._create_rule is None:
-            from sqlalchemy import Table, MetaData
-            temp_table_name = self.get_random_table_name()
-            t=self.connection.begin()
-            self.set_foreignkeys('off')
-            new_table=Table(const.parent, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
-            self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
-            new_table.create()
-            self.move_data(new_table.name,temp_table_name)
-            self.set_foreignkeys("on")
-            self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
-            t.commit()
-            t.close()
-            
-    def move_data(self, new_table_name,old_table_name):
-        self.execute("INSERT INTO %s SELECT * from %s;" % (new_table_name, old_table_name))
-            
-    def collect_constraints(self, table_name, engine):
-        from sqlalchemy import inspect
-        insp=inspect(engine)
-        insp.get_pk_constraint(table_name)
-        insp.get_columns(table_name)
-        insp.get_foreign_keys(table_name)
-        insp.get_sorted_table_and_fkc_names()
-
-    def set_foreignkeys(self, state):
-        sql="PRAGMA foreign_keys=%s;" % state
-        self.connection.execute(sql)
-
-    def get_random_table_name(self, len=8):
-        import random, string
-        return 'temp_'+''.join(random.choices(string.ascii_lowercase + string.digits, k=len))
+            raise NotImplementedError(
+                "No support for ALTER of constraints in SQLite dialect"
+            )
 
     def compare_server_default(
         self,

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -33,20 +33,20 @@ class SQLiteImpl(DefaultImpl):
         if const._create_rule is None:
             raise NotImplementedError(
                 "No support for ALTER of constraints in SQLite dialect"
-                "Try to enable batch-mode during auto-migration"
+                "Please refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy."
             )
         elif const._create_rule(self):
             util.warn(
                 "Skipping unsupported ALTER for "
                 "creation of implicit constraint"
-                "Try to enable batch-mode during auto-migration"
+                "Please refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy."
             )
 
     def drop_constraint(self, const):
         if const._create_rule is None:
             raise NotImplementedError(
                 "No support for ALTER of constraints in SQLite dialect"
-                "Try to enable batch-mode during auto-migration"
+                "Please refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy."
                 
             )
 

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -2,7 +2,7 @@ import re
 
 from .impl import DefaultImpl
 from .. import util
-
+from sqlalchemy import Table, MetaData
 
 class SQLiteImpl(DefaultImpl):
     __dialect__ = "sqlite"
@@ -40,36 +40,67 @@ class SQLiteImpl(DefaultImpl):
                 "creation of implicit constraint"
             )
 
+    def drop_column(self, table_name, column, schema=None, **kw):
+        util.warn("dropping columns in sqlite is experimental. "
+                  "ensure constraints and foreign keys are still correct. only use it for dev")
+
+        temp_table_name = self.get_random_table_name()
+        self.set_foreignkeys('OFF')
+        old_table=Table(table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+        new_column_list= [x.name for x in old_table.columns._all_columns if x.name != column.name]
+        new_table=Table(table_name, MetaData(bind=self.connection.engine), include_columns=new_column_list, autoload=True,autoload_with=self.connection.engine)
+        self.rename_table(table_name,temp_table_name, schema)
+        new_table.create()
+        self.move_data_by_column(new_table.name,temp_table_name, new_column_list)
+        self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
+        self.set_foreignkeys('ON')
+
     def drop_constraint(self, const):
-        if const._create_rule is None:
-            from sqlalchemy import Table, MetaData
-            temp_table_name = self.get_random_table_name()
-            t=self.connection.begin()
-            self.set_foreignkeys('off')
-            new_table=Table(const.parent, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
-            self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
-            new_table.create()
-            self.move_data(new_table.name,temp_table_name)
-            self.set_foreignkeys("on")
-            self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
-            t.commit()
-            t.close()
-            
+        import pdb; pdb.set_trace()       
+        util.warn("dropping constraints in sqlite is experimental. "
+                  "ensure constraints and foreign keys are still correct. only use it for dev")
+
+        self.set_foreignkeys('OFF')
+
+        temp_table_name = self.get_random_table_name()
+        new_column_list= duplicate_columns(const.table)
+        
+        new_table=Table(const.parent, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+        self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
+        new_table.create()
+        self.move_data(new_table.name,temp_table_name)
+        self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
+        self.set_foreignkeys('ON')
+
+    def duplicate_columns(table):
+        [x.name for x in old_table.columns._all_columns if x.name != column.name]
+        old_table=Table(const.table.name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+        ncl=old_table.columns._all_columns
+        col=ncl[-1]
+        from sqlalchemy.sql.schema import Column
+        col2=Column('Creator', INTEGER(),table=old_table)
+        from sqlalchemy.types import TypeEngine
+        from sqlalchemy.types import *
+        col2=Column('Creator', INTEGER())
+        ncl[-1]=col2
+        meta=MetaData()
+        new_table=Table(old_table.name,None,*ncl)
+        new_table=Table(old_table.name,meta,*ncl)
+
     def move_data(self, new_table_name,old_table_name):
         self.execute("INSERT INTO %s SELECT * from %s;" % (new_table_name, old_table_name))
-            
-    def collect_constraints(self, table_name, engine):
-        from sqlalchemy import inspect
-        insp=inspect(engine)
-        insp.get_pk_constraint(table_name)
-        insp.get_columns(table_name)
-        insp.get_foreign_keys(table_name)
-        insp.get_sorted_table_and_fkc_names()
+
+    def move_data_by_column(self, new_table_name,old_table_name, columns):
+        self.execute("INSERT INTO %s SELECT %s from %s;" % (new_table_name, ','.join(columns), old_table_name))
 
     def set_foreignkeys(self, state):
-        sql="PRAGMA foreign_keys=%s;" % state
-        self.connection.execute(sql)
-
+        sql_foreignkeys="PRAGMA foreign_keys = %s;" % state
+        sql_legacyalter='PRAGMA legacy_alter_table=%s;' % ( 'OFF' if state=='ON' else 'ON')
+        self.connection.execute(sql_foreignkeys)
+        self.connection.execute(sql_legacyalter)
+        result=self.connection.execute("PRAGMA foreign_keys;")
+        self.static_output("pragma is"+str(result.fetchone()[0]))
+        
     def get_random_table_name(self, len=8):
         import random, string
         return 'temp_'+''.join(random.choices(string.ascii_lowercase + string.digits, k=len))

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -42,9 +42,37 @@ class SQLiteImpl(DefaultImpl):
 
     def drop_constraint(self, const):
         if const._create_rule is None:
-            raise NotImplementedError(
-                "No support for ALTER of constraints in SQLite dialect"
-            )
+            from sqlalchemy import Table, MetaData
+            temp_table_name = self.get_random_table_name()
+            t=self.connection.begin()
+            self.set_foreignkeys('off')
+            new_table=Table(const.parent, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+            self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
+            new_table.create()
+            self.move_data(new_table.name,temp_table_name)
+            self.set_foreignkeys("on")
+            self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
+            t.commit()
+            t.close()
+            
+    def move_data(self, new_table_name,old_table_name):
+        self.execute("INSERT INTO %s SELECT * from %s;" % (new_table_name, old_table_name))
+            
+    def collect_constraints(self, table_name, engine):
+        from sqlalchemy import inspect
+        insp=inspect(engine)
+        insp.get_pk_constraint(table_name)
+        insp.get_columns(table_name)
+        insp.get_foreign_keys(table_name)
+        insp.get_sorted_table_and_fkc_names()
+
+    def set_foreignkeys(self, state):
+        sql="PRAGMA foreign_keys=%s;" % state
+        self.connection.execute(sql)
+
+    def get_random_table_name(self, len=8):
+        import random, string
+        return 'temp_'+''.join(random.choices(string.ascii_lowercase + string.digits, k=len))
 
     def compare_server_default(
         self,

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -72,7 +72,7 @@ class SQLiteImpl(DefaultImpl):
         self.set_foreignkeys('ON')
 
     def create_constraint(self,const):
-        util.warn("adding constraints in sqlite is experimental. "
+        util.warn("dropping constraints in sqlite is experimental. "
                   "ensure constraints and foreign keys are still correct. only use it for dev")
 
         self.set_foreignkeys('OFF')
@@ -80,22 +80,22 @@ class SQLiteImpl(DefaultImpl):
         temp_table_name = self.get_random_table_name()
         old_table=Table(const.table.name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
         columns= self.duplicate_columns(old_table.columns)
-
+        import pdb; pdb.set_trace()
         enhanced_columns = self.replace_columns(columns,const)
+        #new_column_list = self.replace_columns(const.table.columns,const.columns)
         self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
         new_table=Table(const.parent.name, MetaData(bind=self.connection.engine), *enhanced_columns)
+        #[x._set_parent(new_table) for x in columns_with_constraints]
         new_table.create()
         self.move_data(new_table.name,temp_table_name)
         self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
         self.set_foreignkeys('ON')
 
     def replace_columns(self, columns,new_constrained_bound_columns):
-        unbound_columns_with_constraints=self.duplicate_columns(new_constrained_bound_columns)
+        unbound_columns_with_constraints=self.duplicate_columns()
         for constraint in unbound_columns_with_constraints:
-            fixed_columns=[constraint if constraint.name==x.name else x for x in columns]
-        for old,new in zip(columns,fixed_columns):
-            new.type=old.type
-
+            columns=[constraint if constraint.name==x.name else x for x in columns]
+            [ setattr(x,'type_',x._type) 
         return columns
     
     def remove_constraint(self, columns,const_name,table_name):    
@@ -103,7 +103,7 @@ class SQLiteImpl(DefaultImpl):
             raise "Unnamed ForeignKey, don't know how to drop that"
         if '_fk' not in const_name:
             raise "ForeignKey name not in expected format 'tablename_columnname_fkey'"
-        column_name=const_name.split('_')[-2]
+        column_name=const_name.strip(table_name).strip('_fkey')
         column=[x for x in columns if x.name == column_name][0]
         foreignkeys_to_keep={x for x in column.foreign_keys if not x.column.name==column.name}
         column.foreign_keys=foreignkeys_to_keep
@@ -126,6 +126,8 @@ class SQLiteImpl(DefaultImpl):
         sql_legacyalter='PRAGMA legacy_alter_table=%s;' % ( 'OFF' if state=='ON' else 'ON')
         self.connection.execute(sql_foreignkeys)
         self.connection.execute(sql_legacyalter)
+        result=self.connection.execute("PRAGMA foreign_keys;")
+        self.static_output("pragma is"+str(result.fetchone()[0]))
         
     def get_random_table_name(self, len=8):
         import random, string

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -3,6 +3,7 @@ import re
 from .impl import DefaultImpl
 from .. import util
 from sqlalchemy import Table, MetaData
+from sqlalchemy.types import *
 
 class SQLiteImpl(DefaultImpl):
     __dialect__ = "sqlite"
@@ -31,9 +32,7 @@ class SQLiteImpl(DefaultImpl):
         # attempt to distinguish between an
         # auto-gen constraint and an explicit one
         if const._create_rule is None:
-            raise NotImplementedError(
-                "No support for ALTER of constraints in SQLite dialect"
-            )
+            self.create_constraint(const)
         elif const._create_rule(self):
             util.warn(
                 "Skipping unsupported ALTER for "
@@ -56,36 +55,65 @@ class SQLiteImpl(DefaultImpl):
         self.set_foreignkeys('ON')
 
     def drop_constraint(self, const):
-        import pdb; pdb.set_trace()       
         util.warn("dropping constraints in sqlite is experimental. "
                   "ensure constraints and foreign keys are still correct. only use it for dev")
 
         self.set_foreignkeys('OFF')
 
         temp_table_name = self.get_random_table_name()
-        new_column_list= duplicate_columns(const.table)
-        
-        new_table=Table(const.parent, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+        old_table=Table(const.table.name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
+        new_column_list= self.duplicate_columns(old_table.columns._all_columns)
+        reduced_columns = self.remove_constraint(new_column_list,const.name, const.parent.name)
+        new_table=Table(const.parent.name, MetaData(bind=self.connection.engine), *reduced_columns)
         self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
         new_table.create()
         self.move_data(new_table.name,temp_table_name)
         self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
         self.set_foreignkeys('ON')
 
-    def duplicate_columns(table):
-        [x.name for x in old_table.columns._all_columns if x.name != column.name]
+    def create_constraint(self,const):
+        util.warn("dropping constraints in sqlite is experimental. "
+                  "ensure constraints and foreign keys are still correct. only use it for dev")
+
+        self.set_foreignkeys('OFF')
+
+        temp_table_name = self.get_random_table_name()
         old_table=Table(const.table.name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine)
-        ncl=old_table.columns._all_columns
-        col=ncl[-1]
-        from sqlalchemy.sql.schema import Column
-        col2=Column('Creator', INTEGER(),table=old_table)
-        from sqlalchemy.types import TypeEngine
-        from sqlalchemy.types import *
-        col2=Column('Creator', INTEGER())
-        ncl[-1]=col2
-        meta=MetaData()
-        new_table=Table(old_table.name,None,*ncl)
-        new_table=Table(old_table.name,meta,*ncl)
+        columns= self.duplicate_columns(old_table.columns)
+        import pdb; pdb.set_trace()
+        enhanced_columns = self.replace_columns(columns,const)
+        #new_column_list = self.replace_columns(const.table.columns,const.columns)
+        self.rename_table(const.parent.name,temp_table_name, const.parent.schema)
+        new_table=Table(const.parent.name, MetaData(bind=self.connection.engine), *enhanced_columns)
+        #[x._set_parent(new_table) for x in columns_with_constraints]
+        new_table.create()
+        self.move_data(new_table.name,temp_table_name)
+        self.drop_table(Table(temp_table_name, MetaData(bind=self.connection.engine), autoload=True,autoload_with=self.connection.engine))
+        self.set_foreignkeys('ON')
+
+    def replace_columns(self, columns,new_constrained_bound_columns):
+        unbound_columns_with_constraints=self.duplicate_columns()
+        for constraint in unbound_columns_with_constraints:
+            columns=[constraint if constraint.name==x.name else x for x in columns]
+            [ setattr(x,'type_',x._type) 
+        return columns
+    
+    def remove_constraint(self, columns,const_name,table_name):    
+        if const_name is None:
+            raise "Unnamed ForeignKey, don't know how to drop that"
+        if '_fk' not in const_name:
+            raise "ForeignKey name not in expected format 'tablename_columnname_fkey'"
+        column_name=const_name.strip(table_name).strip('_fkey')
+        column=[x for x in columns if x.name == column_name][0]
+        foreignkeys_to_keep={x for x in column.foreign_keys if not x.column.name==column.name}
+        column.foreign_keys=foreignkeys_to_keep
+        return columns;
+    
+    def duplicate_columns(self,bound_columns):
+        free_columns=[x.copy() for x in bound_columns]
+        for f,b in zip(free_columns,bound_columns):
+            f.foreign_keys=b.foreign_keys
+        return free_columns
 
     def move_data(self, new_table_name,old_table_name):
         self.execute("INSERT INTO %s SELECT * from %s;" % (new_table_name, old_table_name))

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -33,17 +33,21 @@ class SQLiteImpl(DefaultImpl):
         if const._create_rule is None:
             raise NotImplementedError(
                 "No support for ALTER of constraints in SQLite dialect"
+                "Try to enable batch-mode during auto-migration"
             )
         elif const._create_rule(self):
             util.warn(
                 "Skipping unsupported ALTER for "
                 "creation of implicit constraint"
+                "Try to enable batch-mode during auto-migration"
             )
 
     def drop_constraint(self, const):
         if const._create_rule is None:
             raise NotImplementedError(
                 "No support for ALTER of constraints in SQLite dialect"
+                "Try to enable batch-mode during auto-migration"
+                
             )
 
     def compare_server_default(


### PR DESCRIPTION
These changes implement drop_constraint, drop_column and create_constraint on sqlite. 

It might require some advice on rework (that I'm happy to do) since it feels that abstraction layers were broken.




