### PR TITLE
Fixes#528: Removed Force Parameter from Base.py

### DIFF
--- a/alembic/ddl/base.py
+++ b/alembic/ddl/base.py
@@ -184,7 +184,7 @@ def format_table_name(compiler, name, schema):
 
 
 def format_column_name(compiler, name):
-    return compiler.preparer.quote(name, None)
+    return compiler.preparer.quote(name)
 
 
 def format_server_default(compiler, default):

--- a/alembic/ddl/base.py
+++ b/alembic/ddl/base.py
@@ -176,7 +176,7 @@ def quote_dotted(name, quote):
 
 
 def format_table_name(compiler, name, schema):
-    quote = functools.partial(compiler.preparer.quote, force=None)
+    quote = functools.partial(compiler.preparer.quote)
     if schema:
         return quote_dotted(schema, quote) + "." + quote(name)
     else:

--- a/docs/build/unreleased/528.rst
+++ b/docs/build/unreleased/528.rst
@@ -1,0 +1,7 @@
+.. change::
+   :tags: bug
+   :tickets: 528
+
+   Fixed issue by removing Force Parameter from Base.py that
+   is causing alembic's tests to fail on the warning.
+   Pull request courtesy Parth Shandilya(ParthS007).


### PR DESCRIPTION
Fixes #528 

- I have removed Force Parameter from Base.py
- I have run the test after changes and they ran successfully.
- @zzzeek, @mikeywaites Please give your review and let me know if I have to do any changes.

Thanks