### PR TITLE
Update documentation for Config

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -40,7 +40,7 @@ class Config(object):
         from alembic.config import Config
         alembic_cfg = Config()
         alembic_cfg.set_main_option("script_location", "myapp:migrations")
-        alembic_cfg.set_main_option("url", "postgresql://foo/bar")
+        alembic_cfg.set_main_option("sqlalchemy.url", "postgresql://foo/bar")
         alembic_cfg.set_section_option("mysection", "foo", "bar")
 
     .. warning::


### PR DESCRIPTION
Replace "url" with "sqlalchemy.url" in example use of Config object. Fixes #536.