### PR TITLE
remove unnecessary "from __future__ import with_statement" from env templates

### DIFF
--- a/alembic/templates/generic/env.py
+++ b/alembic/templates/generic/env.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 
 from logging.config import fileConfig
 

--- a/alembic/templates/multidb/env.py
+++ b/alembic/templates/multidb/env.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 
 import logging
 from logging.config import fileConfig


### PR DESCRIPTION
That future import is only required for Python 2.5. alembic 1.0 requires Python 2.7 at least so
we can drop this line.