### PR TITLE
fix immutabledict is not defined when using custom migrations

### DIFF
--- a/alembic/op.py
+++ b/alembic/op.py
@@ -1,3 +1,4 @@
+from .util.langhelpers import immutabledict
 from .operations.base import Operations
 
 # create proxy functions for


### PR DESCRIPTION
I have a project that implements a custom migration for PostgreSQL materialized views. However, after upgrading to the latest alembic, it started breaking with an obscure error about `immutabledict` not being defined. (My code doesn't use that import). This PR fixes the problem for me, but I'm not sure if it's "correct."

The custom migration in question is [here](https://github.com/briancappello/flask-unchained/blob/master/flask_unchained/bundles/sqlalchemy/alembic/materialized_view.py) - when Python tries to run the very first import in the file, it blows up. Traceback:

```
  File "/home/brian/.virtualenvs/project/lib/python3.6/site-packages/flask_unchained/bundles/sqlalchemy/__init__.py", line 5, in <module>
    from .alembic import MaterializedViewMigration
  File "/home/brian/.virtualenvs/project/lib/python3.6/site-packages/flask_unchained/bundles/sqlalchemy/alembic/__init__.py", line 1, in <module>
    from .materialized_view import MaterializedViewMigration
  File "/home/brian/.virtualenvs/project/lib/python3.6/site-packages/flask_unchained/bundles/sqlalchemy/alembic/materialized_view.py", line 1, in <module>
    from alembic.autogenerate import comparators, renderers
  File "/home/brian/dev/alembic/alembic/__init__.py", line 5, in <module>
    from . import op  # noqa
  File "/home/brian/dev/alembic/alembic/op.py", line 6, in <module>
    Operations.create_module_class_proxy(globals(), locals())
  File "/home/brian/dev/alembic/alembic/util/langhelpers.py", line 56, in create_module_class_proxy
    cls._setup_proxy(globals_, locals_, attr_names)
  File "/home/brian/dev/alembic/alembic/util/langhelpers.py", line 61, in _setup_proxy
    cls._add_proxied_attribute(methname, globals_, locals_, attr_names)
  File "/home/brian/dev/alembic/alembic/util/langhelpers.py", line 69, in _add_proxied_attribute
    methname, globals_, locals_
  File "/home/brian/dev/alembic/alembic/util/langhelpers.py", line 176, in _create_method_proxy
    exec_(func_text, globals_, lcl)
  File "<string>", line 1, in <module>
NameError: name 'immutabledict' is not defined
```

(I have alembic installed in editable mode here, but it happens when installed from pip just the same)

Happy to help debug this further if necessary, just not sure how :/