### PR TITLE
Feature/use schema map for add column operations

### DIFF
--- a/alembic/ddl/base.py
+++ b/alembic/ddl/base.py
@@ -176,12 +176,10 @@ def quote_dotted(name, quote):
 
 
 def format_table_name(compiler, name, schema):
-    quote = functools.partial(compiler.preparer.quote)
-    if schema:
-        return quote_dotted(schema, quote) + "." + quote(name)
-    else:
-        return quote(name)
+    from ..operations import schemaobj
 
+    table = schemaobj.SchemaObjects().table(name, schema=schema)
+    return compiler.preparer.format_table(table)
 
 def format_column_name(compiler, name):
     return compiler.preparer.quote(name)

--- a/alembic/testing/env.py
+++ b/alembic/testing/env.py
@@ -48,7 +48,7 @@ def staging_env(create=True, template="generic", sourceless=False):
         _try_out(
             lambda: _delete_path_if_exists(path), 
             tries = 5, 
-            ExceptionType = PermissionError
+            ExceptionType = Exception
         )
 						
         command.init(cfg, path, template=template)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -3,6 +3,7 @@ import inspect
 from io import BytesIO
 from io import TextIOWrapper
 import re
+import os
 
 from sqlalchemy import exc as sqla_exc
 
@@ -96,7 +97,7 @@ finally:
             assert_lines.insert(0, "environment included OK")
 
         eq_(
-            buf.getvalue().decode("ascii", "replace").strip(),
+            buf.getvalue().decode("ascii", "replace").strip().replace('\r', ''),
             "\n".join(assert_lines)
             .encode("ascii", "replace")
             .decode("ascii")
@@ -658,9 +659,11 @@ class EditTest(TestBase):
         command.stamp(self.cfg, "base")
 
     def test_edit_head(self):
-        expected_call_arg = "%s/scripts/versions/%s_revision_c.py" % (
-            EditTest.cfg.config_args["here"],
-            EditTest.c,
+        expected_call_arg = os.path.join(
+            "%s" % EditTest.cfg.config_args["here"],
+            "scripts",
+            "versions",
+            "%s_revision_c.py" % EditTest.c,
         )
 
         with mock.patch("alembic.util.edit") as edit:
@@ -668,9 +671,11 @@ class EditTest(TestBase):
             edit.assert_called_with(expected_call_arg)
 
     def test_edit_b(self):
-        expected_call_arg = "%s/scripts/versions/%s_revision_b.py" % (
-            EditTest.cfg.config_args["here"],
-            EditTest.b,
+        expected_call_arg = os.path.join(
+            "%s" % EditTest.cfg.config_args["here"], 
+            "scripts", 
+            "versions", 
+            "%s_revision_b.py" % EditTest.b
         )
 
         with mock.patch("alembic.util.edit") as edit:
@@ -706,9 +711,11 @@ class EditTest(TestBase):
         )
 
     def test_edit_current(self):
-        expected_call_arg = "%s/scripts/versions/%s_revision_b.py" % (
-            EditTest.cfg.config_args["here"],
-            EditTest.b,
+        expected_call_arg = os.path.join(
+            "%s" % EditTest.cfg.config_args["here"],
+            "scripts",
+            "versions",
+            "%s_revision_b.py" % EditTest.b,
         )
 
         command.stamp(self.cfg, self.b)

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -1115,7 +1115,7 @@ def downgrade():
                         "model1",
                         "%s_model1.py" % self.model1,
                     )
-                )
+                ).replace('\\', '\\\\')
             )
         ):
             script = ScriptDirectory.from_config(self.cfg)


### PR DESCRIPTION
This pull-requests addresses issue #555 It implements the workaround mentioned in the issue.

It has been tested on windows with sqlite, sqlite-file and postgresql.

**Note**: Without any changes several unit-tests failed. I found some issues here and fixed them. That were mainly:
* some anti-virus applications block high frequency file operations, that's why it is important to add a wait and re-try mechanism when using a temporary directory, which is cleaned-up for every new test
* since the path separators for windows are different than for linux, some unit-test failed. I fixed this by using `os.path.join` instead of hard coded separator. 
* a very similar issue happened with `\r\n` line-endings on windows, which where produced in some cases
* also keep in mind, that in regex `\\` is used for escaping, if a string contains windows path-separators, they must be escaped as well by doing `\\` => `\\\\`

When postgresql is enabled as database during tests, 110 tests fail. I was not able to find the reason for that, since the test purpose is not always obvious. However they already failed without the changes applied. The failing tests are:

```
=========================== short test summary info ===========================
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_add_column_comment
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_add_table_comment
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_alter_column_comment
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_alter_table_comment
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_existing_column_comment_no_change
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_existing_table_comment_no_change
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_remove_column_comment
FAIL tests/test_autogen_comments.py::AutogenerateCommentsTest_postgresql+psycopg2_11_1::()::test_remove_table_comment
FAIL tests/test_autogen_composition.py::AutogenerateDiffTestWSchema::()::test_render_diffs_extras
FAIL tests/test_autogen_diffs.py::AutogenCustomVersionTableAndSchemaTest_postgresql+psycopg2_11_1::()::test_no_version_table
FAIL tests/test_autogen_diffs.py::AutogenCustomVersionTableAndSchemaTest_postgresql+psycopg2_11_1::()::test_version_table_in_target
FAIL tests/test_autogen_diffs.py::AutogenCustomVersionTableSchemaTest_postgresql+psycopg2_11_1::()::test_no_version_table
FAIL tests/test_autogen_diffs.py::AutogenCustomVersionTableSchemaTest_postgresql+psycopg2_11_1::()::test_version_table_in_target
FAIL tests/test_autogen_diffs.py::AutogenDefaultSchemaTest_postgresql+psycopg2_11_1::()::test_uses_explcit_schema_in_default_one
FAIL tests/test_autogen_diffs.py::AutogenDefaultSchemaTest_postgresql+psycopg2_11_1::()::test_uses_explcit_schema_in_default_three
FAIL tests/test_autogen_diffs.py::AutogenDefaultSchemaTest_postgresql+psycopg2_11_1::()::test_uses_explcit_schema_in_default_two
FAIL tests/test_autogen_diffs.py::AutogenSystemColTest::()::test_dont_add_system
FAIL tests/test_autogen_diffs.py::AutogenerateDiffTestWSchema_postgresql+psycopg2_11_1::()::test_diffs
FAIL tests/test_autogen_diffs.py::AutogenerateVariantCompareTest_postgresql+psycopg2_11_1::()::test_variant_no_issue
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_compositepk_explicit_true
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_compositepk_false
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_compositepk_implicit_false
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_none
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_nonpk_explicit_true
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_nonpk_false
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_nonpk_implicit_false
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_pk_explicit_true
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_pk_false
FAIL tests/test_autogen_diffs.py::AutoincrementTest_postgresql+psycopg2_11_1::()::test_alter_column_autoincrement_pk_implicit_true
FAIL tests/test_autogen_diffs.py::PGCompareMetaData_postgresql+psycopg2_11_1::()::test_compare_metadata_schema
FAIL tests/test_autogen_diffs.py::PKConstraintUpgradesIgnoresNullableTest_postgresql+psycopg2_11_1::()::test_no_change
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_deferrable
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_initially_deferrable_nochange_one
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_initially_deferrable_nochange_three
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_initially_deferrable_nochange_two
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_initially_deferred
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_initially_immediate_plus_deferrable
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_ondelete
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_add_onupdate
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_change_ondelete_from_restrict
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_change_onupdate_from_restrict
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_ondelete
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_ondelete_noaction
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_ondelete_restrict
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_onupdate
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_onupdate_noaction
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_nochange_onupdate_restrict
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_ondelete_onupdate_combo
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_remove_deferrable
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_remove_initially_deferred
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_remove_initially_immediate_plus_deferrable
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_remove_ondelete
FAIL tests/test_autogen_fks.py::AutogenerateFKOptionsTest_postgresql+psycopg2_11_1::()::test_remove_onupdate
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_add_composite_fk_with_name
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_add_fk
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_add_fk_colkeys
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_no_change
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_no_change_colkeys
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_no_change_composite_fk
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_remove_composite_fk
FAIL tests/test_autogen_fks.py::AutogenerateForeignKeysTest_postgresql+psycopg2_11_1::()::test_remove_fk
FAIL tests/test_autogen_fks.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_add_metadata_fk
FAIL tests/test_autogen_fks.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_change_fk
FAIL tests/test_autogen_fks.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_remove_connection_fk
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_add_metadata_index
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_add_metadata_unique
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_change_index
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_change_unique
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_remove_connection_index
FAIL tests/test_autogen_indexes.py::IncludeHooksTest_postgresql+psycopg2_11_1::()::test_remove_connection_uq
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_add_idx_non_col
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_add_ix_on_table_create
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_add_unique_constraint
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_add_uq_ix_on_table_create
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_dont_add_uq_on_table_create
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_drop_table_w_indexes
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_drop_table_w_uq_constraint
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_functional_ix_one
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_functional_ix_two
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_idx_added_schema
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_idx_unchanged_schema
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_index_becomes_unique
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_index_flag_becomes_named_unique_constraint
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_mismatch_db_named_col_flag
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_named_cols_changed
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_new_idx_index_named_as_column
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_implicit_composite_fk_index_named
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_implicit_fk_index_named
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_index_named_as_column
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_index_w_colkeys
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_one
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_two
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_nothing_changed_unique_w_colkeys
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_remove_named_unique_constraint
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_remove_named_unique_index
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_removed_idx_index_named_as_column
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_same_tname_two_schemas
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_unchanged_case_sensitive_explicit_idx
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_unchanged_case_sensitive_implicit_idx
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_unchanged_idx_non_col
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_unique_flag_nothing_changed
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_unnamed_cols_changed
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_uq_added_schema
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_uq_dropped
FAIL tests/test_autogen_indexes.py::PGUniqueIndexTest_postgresql+psycopg2_11_1::()::test_uq_unchanged_schema
FAIL tests/test_batch.py::BatchRoundTripPostgresqlTest_postgresql+psycopg2_11_1::()::test_add_ck_constraint
FAIL tests/test_batch.py::BatchRoundTripPostgresqlTest_postgresql+psycopg2_11_1::()::test_add_column_recreate
FAIL tests/test_batch.py::BatchRoundTripPostgresqlTest_postgresql+psycopg2_11_1::()::test_add_pk_constraint
FAIL tests/test_batch.py::BatchRoundTripPostgresqlTest_postgresql+psycopg2_11_1::()::test_create_drop_index
FAIL tests/test_batch.py::BatchRoundTripPostgresqlTest_postgresql+psycopg2_11_1::()::test_drop_column_fk_recreate
=========== 110 failed, 1140 passed, 134 skipped in 105.94 seconds ============
```

Here is an example error of a failing test:

```
================================== FAILURES ===================================
__ AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_add_column_comment __
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 161, in test_add_column_comment
    "the amount",
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: [('remove_table', Table('_alembic_tmp_foo', MetaData(bind=None), Column('id', INTEGER(), table=<_alembic_tmp_foo>, primary_key=True, nullable=False), Column('data', VARCHAR(length=50), table=<_alembic_tmp_foo>), Column('x', INTEGER(), table=<_alembic_tmp_foo>), schema=None)), ('remove_table', Table('_alembic_tmp_nopk', MetaData(bind=None), Column('a', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('b', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('c', INTEGER(), table=<_alembic_tmp_nopk>), schema=None)), [('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': DOUBLE_PRECISION(precision=53), 'existing_server_default': False}, None, 'the amount')]] != [[('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': <ANY>, 'existing_server_default': False}, None, 'the amount')]]
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
File c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini already exists, skipping
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
__ AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_add_table_comment ___
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 59, in test_add_table_comment
    eq_(diffs[0][0], "add_table_comment")
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: 'remove_table' != 'add_table_comment'
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
_ AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_alter_column_comment _
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 242, in test_alter_column_comment
    "the adjusted amount",
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: [('remove_table', Table('_alembic_tmp_foo', MetaData(bind=None), Column('id', INTEGER(), table=<_alembic_tmp_foo>, primary_key=True, nullable=False), Column('data', VARCHAR(length=50), table=<_alembic_tmp_foo>), Column('x', INTEGER(), table=<_alembic_tmp_foo>), schema=None)), ('remove_table', Table('_alembic_tmp_nopk', MetaData(bind=None), Column('a', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('b', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('c', INTEGER(), table=<_alembic_tmp_nopk>), schema=None)), [('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': DOUBLE_PRECISION(precision=53), 'existing_server_default': False}, 'the amount', 'the adjusted amount')]] != [[('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': <ANY>, 'existing_server_default': False}, 'the amount', 'the adjusted amount')]]
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
_ AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_alter_table_comment __
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 101, in test_alter_table_comment
    eq_(diffs[0][0], "add_table_comment")
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: 'remove_table' != 'add_table_comment'
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
 AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_existing_column_comment_no_change
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 125, in test_existing_column_comment_no_change
    eq_(diffs, [])
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: [('remove_table', Table('_alembic_tmp_foo', MetaData(bind=None), Column('id', INTEGER(), table=<_alembic_tmp_foo>, primary_key=True, nullable=False), Column('data', VARCHAR(length=50), table=<_alembic_tmp_foo>), Column('x', INTEGER(), table=<_alembic_tmp_foo>), schema=None)), ('remove_table', Table('_alembic_tmp_nopk', MetaData(bind=None), Column('a', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('b', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('c', INTEGER(), table=<_alembic_tmp_nopk>), schema=None))] != []
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
 AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_existing_table_comment_no_change
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 42, in test_existing_table_comment_no_change
    eq_(diffs, [])
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: [('remove_table', Table('_alembic_tmp_foo', MetaData(bind=None), Column('id', INTEGER(), table=<_alembic_tmp_foo>, primary_key=True, nullable=False), Column('data', VARCHAR(length=50), table=<_alembic_tmp_foo>), Column('x', INTEGER(), table=<_alembic_tmp_foo>), schema=None)), ('remove_table', Table('_alembic_tmp_nopk', MetaData(bind=None), Column('a', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('b', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('c', INTEGER(), table=<_alembic_tmp_nopk>), schema=None))] != []
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
 AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_remove_column_comment _
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 201, in test_remove_column_comment
    None,
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: [('remove_table', Table('_alembic_tmp_foo', MetaData(bind=None), Column('id', INTEGER(), table=<_alembic_tmp_foo>, primary_key=True, nullable=False), Column('data', VARCHAR(length=50), table=<_alembic_tmp_foo>), Column('x', INTEGER(), table=<_alembic_tmp_foo>), schema=None)), ('remove_table', Table('_alembic_tmp_nopk', MetaData(bind=None), Column('a', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('b', INTEGER(), table=<_alembic_tmp_nopk>, primary_key=True, nullable=False), Column('c', INTEGER(), table=<_alembic_tmp_nopk>), schema=None)), [('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': DOUBLE_PRECISION(precision=53), 'existing_server_default': False}, 'the amount', None)]] != [[('modify_comment', None, 'some_table', 'amount', {'existing_nullable': True, 'existing_type': <ANY>, 'existing_server_default': False}, 'the amount', None)]]
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
_ AutogenerateCommentsTest_postgresql+psycopg2_11_1.test_remove_table_comment _
Traceback (most recent call last):
  File "c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\tests\test_autogen_comments.py", line 78, in test_remove_table_comment
    eq_(diffs[0][0], "remove_table_comment")
  File "C:\Users\VWWPGUD\AppData\Local\Continuum\anaconda3\envs\torch_python\lib\site-packages\sqlalchemy\testing\assertions.py", line 222, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: 'remove_table' != 'remove_table_comment'
---------------------------- Captured stdout setup ----------------------------
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts ... done
Creating directory c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\versions ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\test_alembic.ini ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\env.py ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\README ... done
Generating c:\Projects\torch\SmartSalesRadar\dependencies\alembic\main\scratch\scripts\script.py.mako ... done
Please edit configuration/connection/logging settings in 'c:\\Projects\\torch\\SmartSalesRadar\\dependencies\\alembic\\main\\scratch\\test_alembic.ini' before proceeding.
```
