### PR TITLE
Check if directory is empty before failing initialization of migrations if directory already exists

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -37,18 +37,19 @@ def init(config, directory, template="generic"):
 
     """
 
-    if os.access(directory, os.F_OK):
-        raise util.CommandError("Directory %s already exists" % directory)
+    if os.access(directory, os.F_OK) and os.listdir(directory):
+        raise util.CommandError("Directory %s already exists and is not empty" % directory)
 
     template_dir = os.path.join(config.get_template_directory(), template)
     if not os.access(template_dir, os.F_OK):
         raise util.CommandError("No such template %r" % template)
 
-    util.status(
-        "Creating directory %s" % os.path.abspath(directory),
-        os.makedirs,
-        directory,
-    )
+    if not os.access(directory, os.F_OK):
+        util.status(
+            "Creating directory %s" % os.path.abspath(directory),
+            os.makedirs,
+            directory,
+        )
 
     versions = os.path.join(directory, "versions")
     util.status(

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -799,10 +799,10 @@ class CommandLineTest(TestBase):
                             assert len(help_text) < 80
         assert not commands, "Commands without help text: %s" % commands
     
-    @mock.patch("alembic.command.os.listdir", return_value = ['file1', 'file2'])
+    @mock.patch("alembic.command.os.listdir", return_value = ["file1", "file2"])
     @mock.patch("alembic.command.os.access", return_value = True)
     def test_init_file_exists_and_is_not_empty(self, mocked_listdir, mocked_access):
-        directory = 'alembic'
+        directory = "alembic"
         assert_raises_message(
             util.CommandError,
             "Directory %s already exists and is not empty" % directory,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -798,3 +798,15 @@ class CommandLineTest(TestBase):
                             # not too long
                             assert len(help_text) < 80
         assert not commands, "Commands without help text: %s" % commands
+    
+    @mock.patch("alembic.command.os.listdir", return_value = ['file1', 'file2'])
+    @mock.patch("alembic.command.os.access", return_value = False)
+    def test_init_file_exists_and_is_not_empty(self, mocked_listdir, mocked_access):
+        directory = 'alembic'
+        assert_raises_message(
+            util.CommandError,
+            "Directory %s already exists and is not empty" % directory,
+            command.init,
+            self.cfg,
+            directory = directory
+        )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -798,15 +798,16 @@ class CommandLineTest(TestBase):
                             # not too long
                             assert len(help_text) < 80
         assert not commands, "Commands without help text: %s" % commands
-    
-    @mock.patch("alembic.command.os.listdir", return_value = ["file1", "file2"])
-    @mock.patch("alembic.command.os.access", return_value = True)
-    def test_init_file_exists_and_is_not_empty(self, mocked_listdir, mocked_access):
-        directory = "alembic"
-        assert_raises_message(
-            util.CommandError,
-            "Directory %s already exists and is not empty" % directory,
-            command.init,
-            self.cfg,
-            directory = directory
-        )
+
+    def test_init_file_exists_and_is_not_empty(self):
+        with mock.patch(
+            "alembic.command.os.listdir", return_value=["file1", "file2"]
+        ), mock.patch("alembic.command.os.access", return_value=True):
+            directory = "alembic"
+            assert_raises_message(
+                util.CommandError,
+                "Directory %s already exists and is not empty" % directory,
+                command.init,
+                self.cfg,
+                directory=directory,
+            )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -800,7 +800,7 @@ class CommandLineTest(TestBase):
         assert not commands, "Commands without help text: %s" % commands
     
     @mock.patch("alembic.command.os.listdir", return_value = ['file1', 'file2'])
-    @mock.patch("alembic.command.os.access", return_value = False)
+    @mock.patch("alembic.command.os.access", return_value = True)
     def test_init_file_exists_and_is_not_empty(self, mocked_listdir, mocked_access):
         directory = 'alembic'
         assert_raises_message(


### PR DESCRIPTION
Previously the command `alembic init {dir_name}` failed if the directory already exists. Now the initialization of migrations fails only if the directory is non-empty. If the directory exists and is empty, the initialization goes on as usual.