### PR TITLE
Report warnings from caller's file/line number, not utils.py

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -476,7 +476,7 @@ def current(config, verbose=False, head_only=False):
     script = ScriptDirectory.from_config(config)
 
     if head_only:
-        util.warn("--head-only is deprecated")
+        util.warn("--head-only is deprecated", stacklevel=3)
 
     def display_version(rev, context):
         if verbose:

--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -156,7 +156,8 @@ class DefaultImpl(with_metaclass(ImplMeta)):
         if autoincrement is not None or existing_autoincrement is not None:
             util.warn(
                 "autoincrement and existing_autoincrement "
-                "only make sense for MySQL"
+                "only make sense for MySQL",
+                stacklevel=3,
             )
         if nullable is not None:
             self._exec(

--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -175,7 +175,8 @@ class MigrationContext(object):
                 util.warn(
                     "'connection' argument to configure() is expected "
                     "to be a sqlalchemy.engine.Connection instance, "
-                    "got %r" % connection
+                    "got %r" % connection,
+                    stacklevel=3
                 )
             dialect = connection.dialect
         elif url:

--- a/alembic/util/messaging.py
+++ b/alembic/util/messaging.py
@@ -69,8 +69,9 @@ def obfuscate_url_pw(u):
     return str(u)
 
 
-def warn(msg):
-    warnings.warn(msg)
+def warn(msg, stacklevel=2):
+    # Dy default report the warning from our caller's file/line-no, not here
+    warnings.warn(msg, stacklevel=stacklevel)
 
 
 def msg(msg, newline=True):


### PR DESCRIPTION
Seeing the warning come from `alembic/util/messaging.py:69` is not very
useful for tacking down the source of the incorrect call.

By default utils.warning will now report the warning from the caller,
but some cases it makes sense to report from the context of the
caller's caller.