### PR TITLE
Fix for mixed os directory path names being parsed properly from .ini file

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -285,7 +285,13 @@ class Config(object):
         indicate a different section.
 
         """
-        return self.get_section_option(self.config_ini_section, name, default)
+        raw_section_option = self.get_section_option(
+            self.config_ini_section, name, default)
+        if name in ('script_location', 'version_locations'):
+            section_option = os.path.normpath(raw_section_option)
+        else:
+            section_option = raw_section_option
+        return section_option
 
 
 class CommandLine(object):


### PR DESCRIPTION
Fix for https://github.com/sqlalchemy/alembic/issues/590 to sanitize paths before we assume they exist - so when on windows, the same .ini can be used as would function on linux when parsing a path from the .ini file.