### PR TITLE
Fix alembic.command.stamp() signature and allow revision again

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -515,13 +515,13 @@ def current(config, verbose=False, head_only=False):
         script.run_env()
 
 
-def stamp(config, revisions, sql=False, tag=None, purge=False):
+def stamp(config, revision, sql=False, tag=None, purge=False):
     """'stamp' the revision table with the given revision; don't
     run any migrations.
 
     :param config: a :class:`.Config` instance.
 
-    :param revision: target revision.
+    :param revision: target revision. Can be a list of revisions.
 
     :param sql: use ``--sql`` mode
 
@@ -540,9 +540,9 @@ def stamp(config, revisions, sql=False, tag=None, purge=False):
     if sql:
         destination_revs = []
         starting_rev = None
-        for revision in util.to_list(revisions):
-            if ":" in revision:
-                srev, revision = revision.split(":", 2)
+        for rev in util.to_list(revision):
+            if ":" in rev:
+                srev, rev = rev.split(":", 2)
 
                 if starting_rev != srev:
                     if starting_rev is None:
@@ -552,9 +552,9 @@ def stamp(config, revisions, sql=False, tag=None, purge=False):
                             "Stamp operation with --sql only supports a "
                             "single starting revision at a time"
                         )
-            destination_revs.append(revision)
+            destination_revs.append(rev)
     else:
-        destination_revs = util.to_list(revisions)
+        destination_revs = util.to_list(revision)
 
     def do_stamp(rev, context):
         return script._stamp_revs(util.to_tuple(destination_revs), rev)

--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -7,6 +7,14 @@ Changelog
     :version: 1.2.1
     :include_notes_from: unreleased
 
+    .. change::
+        :tags: bug
+        :tickets: 601
+
+        Version 1.2.0 broke the method signature for alembic.command.stamp().
+        `revision` was no longer a valid method parameter.
+        The paramter `revision` is now valid again but it can still be a list.
+
 .. changelog::
     :version: 1.2.0
     :released: September 20, 2019


### PR DESCRIPTION
Commit [1] changed the method signature. "revision" as parameter name
was no longer accepted. This is now fixed.

Fixes: #601

[1] https://github.com/sqlalchemy/alembic/commit/fdcc5bf973fec758eaf6