### PR TITLE
standardizing to other SqlAlchemy coding conventions:

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,9 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/python/black/
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
     -   id: black
-        args: [-l 79]
 
 -   repo: https://github.com/sqlalchemyorg/zimports/
     rev: master

--- a/README.rst
+++ b/README.rst
@@ -76,3 +76,29 @@ The goals of Alembic are:
 
 Documentation and status of Alembic is at https://alembic.sqlalchemy.org/
 
+The SQLAlchemy Project
+======================
+
+Alembic is part of the `SQLAlchemy Project <https://www.sqlalchemy.org>`_ and
+adheres to the same standards and conventions as the core project.
+
+Development / Bug reporting / Pull requests
+___________________________________________
+
+Please refer to the
+`SQLAlchemy Community Guide <https://www.sqlalchemy.org/develop.html>`_ for
+guidelines on coding and participating in this project.
+
+Code of Conduct
+_______________
+
+Above all, SQLAlchemy places great emphasis on polite, thoughtful, and
+constructive communication between users and developers.
+Please see our current Code of Conduct at
+`Code of Conduct <https://www.sqlalchemy.org/codeofconduct.html>`_.
+
+License
+=======
+
+Alembic is distributed under the `MIT license
+<https://opensource.org/licenses/MIT>`_.

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -266,7 +266,7 @@ try:
 except AttributeError:
     # Python 2
     def exec_(func_text, globals_, lcl):
-        exec("exec func_text in globals_, lcl")
+        exec ("exec func_text in globals_, lcl")
 
 
 ################################################
@@ -298,7 +298,7 @@ if py3k:
 
 
 else:
-    exec(
+    exec (
         "def reraise(tp, value, tb=None, cause=None):\n"
         "    raise tp, value, tb\n"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 79
+target-version = ['py27']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,5 +31,5 @@ bootstrap_file = os.path.join(
 with open(bootstrap_file) as f:
     code = compile(f.read(), "bootstrap.py", "exec")
     to_bootstrap = "pytest"
-    exec(code, globals(), locals())
+    exec (code, globals(), locals())
     from pytestplugin import *  # noqa

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -470,7 +470,7 @@ class MySQLBackendOpTest(AlterColRoundTripFixture, TestBase):
         )
 
     def test_add_timestamp_server_default_current_timestamp_bundle_onupdate(
-        self
+        self,
     ):
         # note SQLAlchemy reflection bundles the ON UPDATE part into the
         # server default reflection see
@@ -485,7 +485,7 @@ class MySQLBackendOpTest(AlterColRoundTripFixture, TestBase):
         )
 
     def test_add_datetime_server_default_current_timestamp_bundle_onupdate(
-        self
+        self,
     ):
         # note SQLAlchemy reflection bundles the ON UPDATE part into the
         # server default reflection see


### PR DESCRIPTION
* migrated `black` config to `pyproject.toml`
* updated black version
* updated README to showcase code-of-conduct and development links

This addresses the repo-wide handling of this situation