### PR TITLE
Access `__file__` as part of generating template path

### DIFF
--- a/alembic/__init__.py
+++ b/alembic/__init__.py
@@ -1,4 +1,3 @@
-from os import path
 import sys
 
 from . import context  # noqa
@@ -7,8 +6,6 @@ from .runtime import environment
 from .runtime import migration
 
 __version__ = '1.3.4'
-
-package_dir = path.abspath(path.dirname(__file__))
 
 sys.modules["alembic.migration"] = migration
 sys.modules["alembic.environment"] = environment

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 from . import command
-from . import package_dir
 from . import util
 from .util import compat
 from .util.compat import SafeConfigParser
@@ -210,6 +209,7 @@ class Config(object):
         commands.
 
         """
+        package_dir = os.path.abspath(os.path.dirname(__file__))
         return os.path.join(package_dir, "templates")
 
     def get_section(self, name, default=None):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This allows importing Alembic in environments
that do not have `__file__` as discussed in #648.

I suppose this falls under 'short code fix' though
I did not include any new tests because failing to locate
the template directory would have caused a number
of existing tests to fail.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
