### PR TITLE
original comparison regex generates false positives in situations whe…

### DIFF
--- a/tests/test_autogen_diffs.py
+++ b/tests/test_autogen_diffs.py
@@ -31,6 +31,7 @@ from sqlalchemy import TypeDecorator
 from sqlalchemy import Unicode
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import VARCHAR
+from sqlalchemy.dialects import mysql
 from sqlalchemy.dialects import sqlite
 from sqlalchemy.types import NULLTYPE
 from sqlalchemy.types import VARBINARY
@@ -841,6 +842,22 @@ class CompareMetadataToInspectorTest(TestBase):
             Integer(),
             True,
             config.requirements.integer_subtype_comparisons,
+        ),
+        (
+            mysql.INTEGER(unsigned=True, display_width=10),
+            mysql.INTEGER(unsigned=True, display_width=10),
+            False,
+        ),
+        (mysql.INTEGER(unsigned=True), mysql.INTEGER(unsigned=True), False),
+        (
+            mysql.INTEGER(unsigned=True, display_width=10),
+            mysql.INTEGER(unsigned=True),
+            False,
+        ),
+        (
+            mysql.INTEGER(unsigned=True),
+            mysql.INTEGER(unsigned=True, display_width=10),
+            False,
         ),
     )
     def test_numeric_comparisons(self, cola, colb, expect_changes):


### PR DESCRIPTION
…re parameters inside parentheses can mix with those outside of it.

See #661 

The previous comparison just split the string on '(,)' breaking out stuff like INTEGER(10, blah=true) into integer, 10, blah=true. Problem was with strings like INTEGER(10) UNSIGNED - it was coming out integer, 10, unsigned ... while INTEGER UNSIGNED comes out as 'integer unsigned'. 

This takes the approach of merging anything before and after the parentheses into a single term. This passes the current tests- but may not be right. It may be more correct here to split on whitespace as well as the parentheses and commas so that "INTEGER UNSIGNED" comes out as integer, unsigned so that it does not generate a diff against integer, 10, unsigned. However, the naive implementation I just described wouldn't work either since `10 != unsigned`.

My feeling is this is a quick fix to the noticed bug, and I should go through some database documentation to get an idea of all the combinations of arguments that will actually show up in real column definitions.


