### PR TITLE
Respects ResultProxy.supports_sane_rowcount()

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -676,14 +676,17 @@ class HeadMaintainer(object):
                 == literal_column("'%s'" % version)
             )
         )
-        if not self.context.as_sql and ret.supports_sane_rowcount():
-            if ret.rowcount != 1:
-                raise util.CommandError(
-                    "Online migration expected to match one "
-                    "row when deleting '%s' in '%s'; "
-                    "%d found"
-                    % (version, self.context.version_table, ret.rowcount)
-                )
+        if (
+            not self.context.as_sql
+            and ret.supports_sane_rowcount()
+            and ret.rowcount != 1
+        ):
+            raise util.CommandError(
+                "Online migration expected to match one "
+                "row when deleting '%s' in '%s'; "
+                "%d found"
+                % (version, self.context.version_table, ret.rowcount)
+            )
 
     def _update_version(self, from_, to_):
         assert to_ not in self.heads
@@ -698,14 +701,17 @@ class HeadMaintainer(object):
                 == literal_column("'%s'" % from_)
             )
         )
-        if not self.context.as_sql and ret.supports_sane_rowcount():
-            if ret.rowcount != 1:
-                raise util.CommandError(
-                    "Online migration expected to match one "
-                    "row when updating '%s' to '%s' in '%s'; "
-                    "%d found"
-                    % (from_, to_, self.context.version_table, ret.rowcount)
-                )
+        if (
+            not self.context.as_sql
+            and ret.supports_sane_rowcount()
+            and ret.rowcount != 1
+        ):
+            raise util.CommandError(
+                "Online migration expected to match one "
+                "row when updating '%s' to '%s' in '%s'; "
+                "%d found"
+                % (from_, to_, self.context.version_table, ret.rowcount)
+            )
 
     def update_to_step(self, step):
         if step.should_delete_branch(self.heads):

--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -676,13 +676,14 @@ class HeadMaintainer(object):
                 == literal_column("'%s'" % version)
             )
         )
-        if not self.context.as_sql and ret.rowcount != 1:
-            raise util.CommandError(
-                "Online migration expected to match one "
-                "row when deleting '%s' in '%s'; "
-                "%d found"
-                % (version, self.context.version_table, ret.rowcount)
-            )
+        if not self.context.as_sql and ret.supports_sane_rowcount():
+            if ret.rowcount != 1:
+                raise util.CommandError(
+                    "Online migration expected to match one "
+                    "row when deleting '%s' in '%s'; "
+                    "%d found"
+                    % (version, self.context.version_table, ret.rowcount)
+                )
 
     def _update_version(self, from_, to_):
         assert to_ not in self.heads
@@ -697,13 +698,14 @@ class HeadMaintainer(object):
                 == literal_column("'%s'" % from_)
             )
         )
-        if not self.context.as_sql and ret.rowcount != 1:
-            raise util.CommandError(
-                "Online migration expected to match one "
-                "row when updating '%s' to '%s' in '%s'; "
-                "%d found"
-                % (from_, to_, self.context.version_table, ret.rowcount)
-            )
+        if not self.context.as_sql and ret.supports_sane_rowcount():
+            if ret.rowcount != 1:
+                raise util.CommandError(
+                    "Online migration expected to match one "
+                    "row when updating '%s' to '%s' in '%s'; "
+                    "%d found"
+                    % (from_, to_, self.context.version_table, ret.rowcount)
+                )
 
     def update_to_step(self, step):
         if step.should_delete_branch(self.heads):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

This PR is for those DBAPIs don't support `rowcount` result of `UPDATE` or `DELETE` statement. e.g., https://github.com/dropbox/PyHive/issues/315

### Description
The scenario is about using alembic + PyHive to manage schema changes of Hive tables. I learned the feature `ResultProxy.supports_sane_rowcount()` from [this mail list](https://groups.google.com/d/msg/sqlalchemy-alembic/t3KmE9KDzH4/ao9u7iRQCgAJ) so this tiny PR is for Alembic to pick it up.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
