### PR TITLE
Fix typo in documentation

### DIFF
--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -287,7 +287,7 @@ class Operations(util.ModuleClsProxy):
          This may be used to provide for additional table options that may
          not be reflected.
 
-        .. versionadded:: 0.7.0
+         .. versionadded:: 0.7.0
 
         :param naming_convention: a naming convention dictionary of the form
          described at :ref:`autogen_naming_conventions` which will be applied


### PR DESCRIPTION
Fixes the wrong version position in `table_kwargs`. 
See: https://alembic.sqlalchemy.org/en/latest/ops.html#alembic.operations.Operations.batch_alter_table

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
