### PR TITLE
Typo fix: appopriate -> appropriate.

### DIFF
--- a/docs/build/naming.rst
+++ b/docs/build/naming.rst
@@ -196,7 +196,7 @@ native boolean types.
 
 We can also use op directives with constraints and not give them a name
 at all, if the naming convention doesn't require one.  The value of
-``None`` will be converted into a name that follows the appopriate naming
+``None`` will be converted into a name that follows the appropriate naming
 conventions::
 
     def upgrade():


### PR DESCRIPTION
### Description

Typo fix: appopriate -> appropriate in "The Importance of Naming Constraints".

### Checklist

This pull request is:

- [x] A documentation / typographical error fix