### PR TITLE
Do not CAST(x as JSON) in SQLite

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -3,6 +3,7 @@ import re
 
 from sqlalchemy import schema
 from sqlalchemy import text
+from sqlalchemy import cast
 
 from . import base
 from .. import util
@@ -448,6 +449,13 @@ class DefaultImpl(with_metaclass(ImplMeta)):
         metadata_indexes,
     ):
         pass
+
+    def cast_for_batch_migrate(self, existing, existing_transfer, new_type):
+        if existing.type._type_affinity is not new_type._type_affinity:
+            existing_transfer["expr"] = cast(
+                existing_transfer["expr"], new_type
+            )
+
 
     def render_ddl_sql_expr(self, expr, is_server_default=False, **kw):
         """Render a SQL expression that is typically a server default,

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -1,5 +1,7 @@
 import re
 
+from sqlalchemy import cast, JSON
+
 from .impl import DefaultImpl
 from .. import util
 
@@ -116,6 +118,15 @@ class SQLiteImpl(DefaultImpl):
         ):
             str_expr = "(%s)" % (str_expr,)
         return str_expr
+
+    def cast_for_batch_migrate(self, existing, existing_transfer, new_type):
+        if (
+            existing.type._type_affinity is not new_type._type_affinity
+            and not isinstance(new_type, JSON)
+        ):
+            existing_transfer["expr"] = cast(
+                existing_transfer["expr"], new_type
+            )
 
 
 # @compiles(AddColumn, 'sqlite')

--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -103,6 +103,7 @@ class BatchOperationsImpl(object):
                 reflected = True
 
             batch_impl = ApplyBatchImpl(
+                self.impl,
                 existing_table,
                 self.table_args,
                 self.table_kwargs,
@@ -155,8 +156,9 @@ class BatchOperationsImpl(object):
 
 class ApplyBatchImpl(object):
     def __init__(
-        self, table, table_args, table_kwargs, reflected, partial_reordering=()
+        self, impl, table, table_args, table_kwargs, reflected, partial_reordering=()
     ):
+        self.impl = impl
         self.table = table  # this is a Table object
         self.table_args = table_args
         self.table_kwargs = table_kwargs
@@ -405,12 +407,14 @@ class ApplyBatchImpl(object):
                     existing.type.create_constraint
                 ) = False
 
-            if existing.type._type_affinity is not type_._type_affinity:
-                existing_transfer["expr"] = cast(
-                    existing_transfer["expr"], type_
-                )
+            self.impl.cast_for_batch_migrate(
+                existing,
+                existing_transfer,
+                type_
+            )
 
             existing.type = type_
+
 
             # we *dont* however set events for the new type, because
             # alter_column is invoked from

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -989,6 +989,7 @@ class CopyFromTest(TestBase):
         self.op = Operations(context)
         return context
 
+    @config.requirements.sqlalchemy_13
     def test_change_type(self):
         context = self._fixture()
         self.table.append_column(Column("toj", Text))

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -36,11 +36,14 @@ from alembic.testing import TestBase
 from alembic.testing.fixtures import op_fixture
 from alembic.util import exc as alembic_exc
 from alembic.util.sqla_compat import sqla_14
+from alembic.ddl import sqlite
+from sqlalchemy.dialects import sqlite as sqlite_dialect
 
 
 class BatchApplyTest(TestBase):
     def setUp(self):
         self.op = Operations(mock.Mock(opts={}))
+        self.impl = sqlite.SQLiteImpl(sqlite_dialect.dialect(), None, False, False, None, {})
 
     def _simple_fixture(self, table_args=(), table_kwargs={}, **kw):
         m = MetaData()
@@ -51,7 +54,7 @@ class BatchApplyTest(TestBase):
             Column("x", String(10)),
             Column("y", Integer),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False, **kw)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False, **kw)
 
     def _uq_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -63,7 +66,7 @@ class BatchApplyTest(TestBase):
             Column("y", Integer),
             UniqueConstraint("y", name="uq1"),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _ix_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -75,7 +78,7 @@ class BatchApplyTest(TestBase):
             Column("y", Integer),
             Index("ix1", "y"),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _pk_fixture(self):
         m = MetaData()
@@ -87,7 +90,7 @@ class BatchApplyTest(TestBase):
             Column("y", Integer),
             PrimaryKeyConstraint("id", name="mypk"),
         )
-        return ApplyBatchImpl(t, (), {}, False)
+        return ApplyBatchImpl(self.impl, t, (), {}, False)
 
     def _literal_ck_fixture(
         self, copy_from=None, table_args=(), table_kwargs={}
@@ -103,7 +106,7 @@ class BatchApplyTest(TestBase):
                 Column("email", String()),
                 CheckConstraint("email LIKE '%@%'"),
             )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _sql_ck_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -114,7 +117,7 @@ class BatchApplyTest(TestBase):
             Column("email", String()),
         )
         t.append_constraint(CheckConstraint(t.c.email.like("%@%")))
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _fk_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -125,7 +128,7 @@ class BatchApplyTest(TestBase):
             Column("email", String()),
             Column("user_id", Integer, ForeignKey("user.id")),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _multi_fk_fixture(self, table_args=(), table_kwargs={}, schema=None):
         m = MetaData()
@@ -149,7 +152,7 @@ class BatchApplyTest(TestBase):
             ),
             schema=schema,
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _named_fk_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -160,7 +163,7 @@ class BatchApplyTest(TestBase):
             Column("email", String()),
             Column("user_id", Integer, ForeignKey("user.id", name="ufk")),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _selfref_fk_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -171,7 +174,7 @@ class BatchApplyTest(TestBase):
             Column("parent_id", Integer, ForeignKey("tname.id")),
             Column("data", String),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _boolean_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -181,7 +184,7 @@ class BatchApplyTest(TestBase):
             Column("id", Integer, primary_key=True),
             Column("flag", Boolean),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _boolean_no_ck_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -191,7 +194,7 @@ class BatchApplyTest(TestBase):
             Column("id", Integer, primary_key=True),
             Column("flag", Boolean(create_constraint=False)),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _enum_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -201,7 +204,7 @@ class BatchApplyTest(TestBase):
             Column("id", Integer, primary_key=True),
             Column("thing", Enum("a", "b", "c")),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _server_default_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -211,7 +214,7 @@ class BatchApplyTest(TestBase):
             Column("id", Integer, primary_key=True),
             Column("thing", String(), server_default=""),
         )
-        return ApplyBatchImpl(t, table_args, table_kwargs, False)
+        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False)
 
     def _assert_impl(
         self,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

When performing a batch operation for SQLite do not use `CAST(x as JSON)` when copying the data.

Instead, just copy the data as-is. SQLite already interprets it as JSON. But when using `CAST(x as JSON)` SQLite parses any JSON to a literal `0`.

This is probably just a bug in SQLite and/or the JSON extension for SQLite not being supported as a type in a `CAST()`. But as there are already other fixes/workarounds for compatibility in SQLAlchemy and Alembic, I thought this could be also included here.

I didn't see any code logic to specifically detect SQLite, but as the batch operations are only used in SQLite, and I saw [another commit](https://github.com/sqlalchemy/alembic/commit/3926ac6b000ed7f3dbdb5376a54f39351b3b4e35) to handle SQLite `CAST()` compatibility in the same section in the code, I thought it could be updated there as well. 

This would fix https://github.com/sqlalchemy/alembic/issues/697

Running the same script from that issue, after applying this, produces (my) expected results, here's the full log:

<details>

```
2020-05-22 19:56:11,678 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1
2020-05-22 19:56:11,678 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,679 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1
2020-05-22 19:56:11,679 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,680 INFO sqlalchemy.engine.base.Engine PRAGMA main.table_info("users")
2020-05-22 19:56:11,680 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,681 INFO sqlalchemy.engine.base.Engine PRAGMA temp.table_info("users")
2020-05-22 19:56:11,681 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,681 INFO sqlalchemy.engine.base.Engine 
CREATE TABLE users (
        id INTEGER NOT NULL, 
        name VARCHAR, 
        data TEXT, 
        PRIMARY KEY (id)
)


2020-05-22 19:56:11,681 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,681 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,682 INFO sqlalchemy.engine.base.Engine INSERT INTO users (name, data) VALUES (?, ?)
2020-05-22 19:56:11,682 INFO sqlalchemy.engine.base.Engine ('Jack', '{"message": "Hello World"}')
2020-05-22 19:56:11,682 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,682 INFO sqlalchemy.engine.base.Engine PRAGMA main.table_info("users")
2020-05-22 19:56:11,682 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,683 INFO sqlalchemy.engine.base.Engine SELECT sql FROM  (SELECT * FROM sqlite_master UNION ALL   SELECT * FROM sqlite_temp_master) WHERE name = 'users' AND type = 'table'
2020-05-22 19:56:11,683 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,683 INFO sqlalchemy.engine.base.Engine PRAGMA main.foreign_key_list("users")
2020-05-22 19:56:11,684 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,684 INFO sqlalchemy.engine.base.Engine PRAGMA temp.foreign_key_list("users")
2020-05-22 19:56:11,684 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,684 INFO sqlalchemy.engine.base.Engine SELECT sql FROM  (SELECT * FROM sqlite_master UNION ALL   SELECT * FROM sqlite_temp_master) WHERE name = 'users' AND type = 'table'
2020-05-22 19:56:11,684 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine PRAGMA main.index_list("users")
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine PRAGMA temp.index_list("users")
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine PRAGMA main.index_list("users")
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine PRAGMA temp.index_list("users")
2020-05-22 19:56:11,685 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,686 INFO sqlalchemy.engine.base.Engine SELECT sql FROM  (SELECT * FROM sqlite_master UNION ALL   SELECT * FROM sqlite_temp_master) WHERE name = 'users' AND type = 'table'
2020-05-22 19:56:11,686 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,687 INFO sqlalchemy.engine.base.Engine 
CREATE TABLE _alembic_tmp_users (
        id INTEGER NOT NULL, 
        name VARCHAR, 
        data JSON, 
        PRIMARY KEY (id)
)


2020-05-22 19:56:11,687 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,687 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine INSERT INTO _alembic_tmp_users (id, name, data) SELECT users.id, users.name, users.data 
FROM users
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine 
DROP TABLE users
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine ALTER TABLE _alembic_tmp_users RENAME TO users
2020-05-22 19:56:11,688 INFO sqlalchemy.engine.base.Engine ()
2020-05-22 19:56:11,689 INFO sqlalchemy.engine.base.Engine COMMIT
2020-05-22 19:56:11,689 INFO sqlalchemy.engine.base.Engine SELECT users.id, users.name, users.data 
FROM users
2020-05-22 19:56:11,689 INFO sqlalchemy.engine.base.Engine ()
Jack, {"message": "Hello World"}
```

</details>

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
