### PR TITLE
Fixes #716. Remove typo in _exec_drop_col_fk_constraint

### DIFF
--- a/alembic/ddl/mssql.py
+++ b/alembic/ddl/mssql.py
@@ -205,7 +205,7 @@ select @const_name = [name] from
 sys.foreign_keys fk join sys.foreign_key_columns fkc
 on fk.object_id=fkc.constraint_object_id
 where fkc.parent_object_id = object_id('%(schema_dot)s%(tname)s')
-`and col_name(fkc.parent_object_id, fkc.parent_column_id) = '%(colname)s'
+and col_name(fkc.parent_object_id, fkc.parent_column_id) = '%(colname)s'
 exec('alter table %(tname_quoted)s drop constraint ' + @const_name)""" % {
         "tname": tname,
         "colname": colname,

--- a/docs/build/unreleased/716.rst
+++ b/docs/build/unreleased/716.rst
@@ -1,0 +1,7 @@
+.. change::
+   :tags: bug, mssql
+   :tickets: 716
+
+   Fixed issue where the ``mssql_drop_foreign_key=True`` flag on ``op.drop_column``
+   would lead to incorrect syntax error.
+   Pull request courtesy Oleg Shigorin(Nuqlear).

--- a/tests/test_mssql.py
+++ b/tests/test_mssql.py
@@ -191,7 +191,7 @@ class OpTest(TestBase):
             "select @const_name = [name] from\n"
             "sys.foreign_keys fk join sys.foreign_key_columns fkcon "
             "fk.object_id=fkc.constraint_object_id\n"
-            "where fkc.parent_object_id = object_id('t1')`and "
+            "where fkc.parent_object_id = object_id('t1')and "
             "col_name(fkc.parent_object_id, fkc.parent_column_id) = 'c1'\n"
             "exec('alter table t1 drop constraint ' + @const_name)"
         )
@@ -208,7 +208,7 @@ class OpTest(TestBase):
             "select @const_name = [name] from\n"
             "sys.foreign_keys fk join sys.foreign_key_columns fkcon "
             "fk.object_id=fkc.constraint_object_id\n"
-            "where fkc.parent_object_id = object_id('xyz.t1')`and "
+            "where fkc.parent_object_id = object_id('xyz.t1')and "
             "col_name(fkc.parent_object_id, fkc.parent_column_id) = 'c1'\n"
             "exec('alter table xyz.t1 drop constraint ' + @const_name)"
         )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

