### PR TITLE
Added detection of Table prefixes in the create table render

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -202,6 +202,11 @@ def _add_table(autogen_context, op):
         text += ",\ncomment=%r" % _ident(comment)
     for k in sorted(op.kw):
         text += ",\n%s=%r" % (k.replace(" ", "_"), op.kw[k])
+
+    if table._prefixes:
+        prefixes = ", ".join("'%s'" % p for p in table._prefixes)
+        text += ",\nprefixes=[%s]" % prefixes
+
     text += "\n)"
     return text
 

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -966,6 +966,43 @@ class AutogenRenderTest(TestBase):
             ")",
         )
 
+    def test_render_table_w_prefixes(self):
+        m = MetaData()
+        t = Table(
+            "test",
+            m,
+            Column("id", Integer, primary_key=True),
+            prefixes=["TEST", "PREFIXES"],
+        )
+        op_obj = ops.CreateTableOp.from_table(t)
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.create_table('test',"
+            "sa.Column('id', sa.Integer(), nullable=False),"
+            "sa.PrimaryKeyConstraint('id'),"
+            "prefixes=['TEST', 'PREFIXES']"
+            ")",
+        )
+
+    def test_render_table_w_prefixes_schema(self):
+        m = MetaData(schema="foo")
+        t = Table(
+            "test",
+            m,
+            Column("id", Integer, primary_key=True),
+            prefixes=["TEST", "PREFIXES"],
+        )
+        op_obj = ops.CreateTableOp.from_table(t)
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.create_table('test',"
+            "sa.Column('id', sa.Integer(), nullable=False),"
+            "sa.PrimaryKeyConstraint('id'),"
+            "schema='foo',"
+            "prefixes=['TEST', 'PREFIXES']"
+            ")",
+        )
+
     def test_render_addtl_args(self):
         m = MetaData()
         t = Table(


### PR DESCRIPTION
### Description
This PR addresses issue #721. As described in the issue, the [`Table.prefixes`](https://docs.sqlalchemy.org/en/13/core/metadata.html#sqlalchemy.schema.Table.params.prefixes) was not being picked up by the `alembic revision --autogenerate`.

TBH, I don't know if there is a better way of getting the `prefixes` other than via the variable `table._prefixes`.


### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
