### PR TITLE
Implement downgrade of a single branch back to a branchpoint.  Fixes: #464

### DIFF
--- a/tests/test_version_traversal.py
+++ b/tests/test_version_traversal.py
@@ -317,6 +317,54 @@ class BranchedPathTest(MigrationTest):
             set([self.c1.revision]),
         )
 
+    def test_downgrade_single_branch_c1branch(self):
+        """ Use branch label to specify the branch to downgrade. """
+        self._assert_downgrade(
+            "c1branch@{}".format(self.b.revision),
+            (self.c1.revision, self.d2.revision),
+            [
+                self.down_(self.c1),
+            ],
+            set([self.d2.revision]),
+        )
+
+    def test_downgrade_single_branch_c1branch_from_d1_head(self):
+        """Use branch label to specify the branch (where the branch label is
+        not on the head revision)."""
+        self._assert_downgrade(
+            "c2branch@{}".format(self.b.revision),
+            (self.c1.revision, self.d2.revision),
+            [
+                self.down_(self.d2),
+                self.down_(self.c2),
+            ],
+            set([self.c1.revision]),
+        )
+
+    def test_downgrade_single_branch_c2(self):
+        """Use a revision on the branch (not head) to specify the branch."""
+        self._assert_downgrade(
+            "{}@{}".format(self.c2.revision, self.b.revision),
+            (self.d1.revision, self.d2.revision),
+            [
+                self.down_(self.d2),
+                self.down_(self.c2),
+            ],
+            set([self.d1.revision]),
+        )
+
+    def test_downgrade_single_branch_d1(self):
+        """ Use the head revision to specify the branch. """
+        self._assert_downgrade(
+            "{}@{}".format(self.d1.revision, self.b.revision),
+            (self.d1.revision, self.d2.revision),
+            [
+                self.down_(self.d1),
+                self.down_(self.c1),
+            ],
+            set([self.d2.revision]),
+        )
+
 
 class BranchFromMergepointTest(MigrationTest):
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Current downgrade behaviour downgrades all branches when asked to downgrade to a branchpoint.  This PR implements syntax suggested in #464 to downgrade single branches.

Basic example:
```
base -> rev1 --> rev2 (brancha)
             +-> rev2a (branchb) -> rev3a
```

a) The following will only downgrade `rev2 -> rev1`, leaving `rev3a` as the single current head:
- `alembic downgrade rev2@rev1`
- `alembic downgrade brancha@rev1`

b) The following will only downgrade `rev3a -> rev2a` and `rev2a -> rev1`, leaving `rev2` as the single current head:
- `alembic downgrade rev3a@rev1`
- `alembic downgrade rev2a@rev1`
- `alembic downgrade branchb@rev1`

Note:

If `rev3a` or `rev2a` depend on `rev2`:

- Case (b) is unchanged
- Case (a) downgrades both branches.  It's only strictly necessary to remove `rev3a` if `rev2a` does not have a dependency, but considering entire branches is simpler to implement and `rev3a` alone can already be removed using `downgrade rev2a`.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
