### PR TITLE
Update cookbook.rst references to #753

### DIFF
--- a/docs/build/cookbook.rst
+++ b/docs/build/cookbook.rst
@@ -1315,7 +1315,7 @@ follows::
                 elem.table_name, schema=elem.schema
             ) as batch_ops:
                 for table_elem in elem.ops:
-                    # work around Alembic issue #753
+                    # work around Alembic issue #753 (fixed in 1.5.0)
                     if hasattr(table_elem, "column"):
                         table_elem.column = table_elem.column.copy()
                     batch_ops.invoke(table_elem)
@@ -1323,7 +1323,7 @@ follows::
         elif hasattr(elem, "ops"):
             stack.extend(elem.ops)
         else:
-            # work around Alembic issue #753
+            # work around Alembic issue #753 (fixed in 1.5.0)
             if hasattr(elem, "column"):
                 elem.column = elem.column.copy()
             operations.invoke(elem)
@@ -1396,7 +1396,7 @@ at :func:`.autogenerate.compare_metadata`::
                 elem.table_name, schema=elem.schema
             ) as batch_ops:
                 for table_elem in elem.ops:
-                    # work around Alembic issue #753
+                    # work around Alembic issue #753 (fixed in 1.5.0)
                     if hasattr(table_elem, "column"):
                         table_elem.column = table_elem.column.copy()
                     batch_ops.invoke(table_elem)
@@ -1404,7 +1404,7 @@ at :func:`.autogenerate.compare_metadata`::
         elif hasattr(elem, "ops"):
             stack.extend(elem.ops)
         else:
-            # work around Alembic issue #753
+            # work around Alembic issue #753 (fixed in 1.5.0)
             if hasattr(elem, "column"):
                 elem.column = elem.column.copy()
             operations.invoke(elem)


### PR DESCRIPTION
### Description
A fix for #753 was merged in November 2020 and [released in 1.5.0](https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.5.0-bug) in January 2021.
This updates the references to #753 in cookbook.rst to note that a fix for #753 has been released.

Alternatively, it may make sense to just delete the workarounds.


### Checklist


This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

