### PR TITLE
[docs] fix versionchanged directive in autogenerate docs

### DIFF
--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -621,7 +621,7 @@ is set to True::
      database backend sets as a default value without generating false
      positives.
 
-..versionchanged 1.4.0:: Added the text and keyword comparison for column types
+.. versionchanged:: 1.4.0 Added the text and keyword comparison for column types
 
 Alternatively, the :paramref:`.EnvironmentContext.configure.compare_type`
 parameter accepts a callable function which may be used to implement custom type


### PR DESCRIPTION
### Description

Thanks for this great project! I've been reading the documentation at https://alembic.sqlalchemy.org/en/latest/, and noticed what I believe is a mistake in the docs on `alembic revision --autogenerate`.

There is a literal Sphinx [`versionchanged` directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionchanged) in the section on comparing types (https://alembic.sqlalchemy.org/en/latest/autogenerate.html#comparing-types).

![image](https://user-images.githubusercontent.com/7608904/108666924-e1af9480-749d-11eb-9796-5feff0ed1d7f.png)

This pull request proposes a fix that will result in this being correctly rendered as a callout box.

![image](https://user-images.githubusercontent.com/7608904/108667159-35ba7900-749e-11eb-856f-fdcb4c48d502.png)

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
- [ ] A short code fix
- [ ] A new feature implementation

### Notes for Reviewers

I tested this by building the docs locally, and it seems to work as expected.

```shell
cd docs/builds
pip install -r requirements.txt
make clean html
```

I also searched for other issues like this with `git grep -E "\.\.[A-za-z]+"` and `git grep -E "\.\. version"`, but didn't find any others that looked problematic.

Thanks for your time and consideration.