### PR TITLE
[doc] clarify ALTER language in batch docs

### DIFF
--- a/docs/build/batch.rst
+++ b/docs/build/batch.rst
@@ -4,7 +4,7 @@ Running "Batch" Migrations for SQLite and Other Databases
 =========================================================
 
 The SQLite database presents a challenge to migration tools
-in that it has almost no support for the ALTER statement upon which
+in that it has almost no support for the ALTER statement
 relational schema migrations rely upon.  The rationale for this stems from
 philosophical and architectural concerns within SQLite, and they are unlikely
 to be changed.

--- a/docs/build/batch.rst
+++ b/docs/build/batch.rst
@@ -4,7 +4,7 @@ Running "Batch" Migrations for SQLite and Other Databases
 =========================================================
 
 The SQLite database presents a challenge to migration tools
-in that it has almost no support for the ALTER statement
+in that it has almost no support for the ALTER statement which
 relational schema migrations rely upon.  The rationale for this stems from
 philosophical and architectural concerns within SQLite, and they are unlikely
 to be changed.
@@ -349,4 +349,3 @@ transactional DDL.
 Note that also as is the case with SQLite, CHECK constraints need to be
 moved over between old and new table manually using the
 :paramref:`.Operations.batch_alter_table.table_args` parameter.
-


### PR DESCRIPTION
### Description

Clarifies language about `ALTER` in the batch migrations docs.

I think the double use of "upon" in this phrase is not quite correct, and confused me when I first read it.

> the ALTER statement upon which relation schema migrations rely upon

This PR proposes changing that to

> the ALTER statement relational schema migrations rely upon.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


Thanks for your time and consideration.
