### PR TITLE
enable extensions to use AutogenContext.run_name_filters #813

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -330,15 +330,16 @@ class AutogenContext(object):
             if type_ == "table":
                 table_name = name
             else:
-                table_name = parent_names["table_name"]
-            schema_name = parent_names["schema_name"]
-            if schema_name:
-                parent_names["schema_qualified_table_name"] = "%s.%s" % (
-                    schema_name,
-                    table_name,
-                )
-            else:
-                parent_names["schema_qualified_table_name"] = table_name
+                table_name = parent_names.get("table_name", None)
+            if table_name:
+                schema_name = parent_names["schema_name"]
+                if schema_name:
+                    parent_names["schema_qualified_table_name"] = "%s.%s" % (
+                        schema_name,
+                        table_name,
+                    )
+                else:
+                    parent_names["schema_qualified_table_name"] = table_name
 
         for fn in self._name_filters:
 

--- a/tests/test_autogen_diffs.py
+++ b/tests/test_autogen_diffs.py
@@ -222,10 +222,15 @@ class AutogenCrossSchemaTest(AutogenTest, TestBase):
             object_filters=include_object, include_schemas=True
         )
 
-        self.autogen_context.run_name_filters(
+        class ExtFunction(object):
+            pass
+
+        self.autogen_context.run_object_filters(
+            object_=ExtFunction(),
             name="some_function",
             type_="function",
-            parent_names={"schema_name": "public"},
+            reflected=False,
+            compare_to=None,
         )
 
     def test_default_schema_omitted_downgrade(self):

--- a/tests/test_autogen_diffs.py
+++ b/tests/test_autogen_diffs.py
@@ -198,6 +198,36 @@ class AutogenCrossSchemaTest(AutogenTest, TestBase):
             },
         )
 
+    def test_run_name_filters_supports_extension_types(self):
+        def include_name(name, type_, parent_names):
+            # extension type successfully passed through
+            # `AutogenContext.run_name_filters`
+            assert True
+
+        self._update_context(name_filters=include_name, include_schemas=True)
+
+        self.autogen_context.run_name_filters(
+            name="some_function",
+            type_="function",
+            parent_names={"schema_name": "public"},
+        )
+
+    def test_run_object_filters_supports_extension_types(self):
+        def include_object(obj, name, type_, reflected, compare_to):
+            # extension type successfully passed through
+            # `AutogenContext.run_object_filters`
+            assert True
+
+        self._update_context(
+            object_filters=include_object, include_schemas=True
+        )
+
+        self.autogen_context.run_name_filters(
+            name="some_function",
+            type_="function",
+            parent_names={"schema_name": "public"},
+        )
+
     def test_default_schema_omitted_downgrade(self):
         def include_object(obj, name, type_, reflected, compare_to):
             if type_ == "table":


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Allows alembic extensions to call `AutogenContext.run_name_filters` so they can be configured using `include_objects` and `include_names` in `env.py`

Fixes: #813

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Sorry in advance if this bounces off CI. The tests are in a `postgresql` only class but those tests kept throwing
```
AssertionError: staging directory scratch/scripts already exists; poor cleanup? 
```
even after following along with the testing docs.
