### PR TITLE
Add cwd post-write hook option

### DIFF
--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -753,15 +753,16 @@ configuration for the ``"black"`` post write hook, which includes:
   function, this configuration variable would refer to the name under
   which the custom hook was registered; see the next section for an example.
 
-* ``entrypoint`` - this part of the configuration is specific to the
-  ``"console_scripts"`` hook runner.  This is the name of the `setuptools entrypoint <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points>`_
+The following configuration options are specific to the ``"console_scripts"``
+hook runner:
+
+* ``entrypoint`` - the name of the `setuptools entrypoint <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points>`_
   that is used to define the console script.   Within the scope of standard
   Python console scripts, this name will match the name of the shell command
   that is usually run for the code formatting tool, in this case ``black``.
 
-* ``options`` - this is also specific to the ``"console_scripts"`` hook runner.
-  This is a line of command-line options that will be passed to the
-  code formatting tool.  In this case, we want to run the command
+* ``options`` - a line of command-line options that will be passed to
+  the code formatting tool.  In this case, we want to run the command
   ``black /path/to/revision.py -l 79``.  By default, the revision path is
   positioned as the first argument.  In order specify a different position,
   we can use the ``REVISION_SCRIPT_FILENAME`` token as illustrated by the
@@ -777,6 +778,7 @@ configuration for the ``"black"`` post write hook, which includes:
         autopep8.entrypoint = autopep8
         autopep8.options = --in-place REVISION_SCRIPT_FILENAME
 
+* ``cwd`` - optional working directory from which the console script is run.
 
 When running ``alembic revision -m "rev1"``, we will now see the ``black``
 tool's output as well::

--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -813,6 +813,20 @@ configuration as follows::
 When using the above configuration, a newly generated revision file will
 be processed first by the "black" tool, then by the "zimports" tool.
 
+Alternatively, one can run pre-commit itself as follows::
+
+  [post_write_hooks]
+
+  hooks = pre-commit
+
+  pre-commit.type = console_scripts
+  pre-commit.entrypoint = pre-commit
+  pre-commit.options = run --files REVISION_SCRIPT_FILENAME
+  pre-commit.cwd = %(here)s
+
+(The last line helps to ensure that the ``.pre-commit-config.yaml`` file
+will always be found, regardless of from where the hook was called.)
+
 .. _post_write_hooks_custom:
 
 Writing Custom Hooks as Python Functions

--- a/docs/build/unreleased/822.rst
+++ b/docs/build/unreleased/822.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: feature
+    :tickets: 822
+
+    Implement a ``.cwd`` (current working directory) suboption for post-write hooks
+    (of type ``console_scripts``). This is useful for tools like pre-commit, which
+    rely on the working directory to locate the necessary config files. Add
+    pre-commit as an example to the documentation. Minor change: rename some variables
+    from ticket #819 to improve readability.

--- a/tests/test_post_write.py
+++ b/tests/test_post_write.py
@@ -149,7 +149,8 @@ class RunHookTest(TestBase):
                         "-c",
                         "import black_module; black_module.foo.bar()",
                     ]
-                    + expected_additional_arguments_fn(rev.path)
+                    + expected_additional_arguments_fn(rev.path),
+                    cwd=None,
                 )
             ],
         )

--- a/tests/test_post_write.py
+++ b/tests/test_post_write.py
@@ -126,7 +126,7 @@ class RunHookTest(TestBase):
         )
 
     def _run_black_with_config(
-        self, input_config, expected_additional_arguments_fn
+        self, input_config, expected_additional_arguments_fn, cwd=None
     ):
         self.cfg = _no_sql_testing_config(directives=input_config)
         impl = mock.Mock(attrs=("foo", "bar"), module_name="black_module")
@@ -150,7 +150,7 @@ class RunHookTest(TestBase):
                         "import black_module; black_module.foo.bar()",
                     ]
                     + expected_additional_arguments_fn(rev.path),
-                    cwd=None,
+                    cwd=cwd,
                 )
             ],
         )
@@ -186,4 +186,20 @@ black.options = arg1 REVISION_SCRIPT_FILENAME 'multi-word arg' \
 
         self._run_black_with_config(
             input_config, expected_additional_arguments_fn
+        )
+
+    def test_black_with_cwd(self):
+        input_config = """
+[post_write_hooks]
+hooks = black
+black.type = console_scripts
+black.entrypoint = black
+black.cwd = /path/to/cwd
+        """
+
+        def expected_additional_arguments_fn(rev_path):
+            return [rev_path]
+
+        self._run_black_with_config(
+            input_config, expected_additional_arguments_fn, cwd="/path/to/cwd"
         )


### PR DESCRIPTION
Fixes #822

Implements a `.cwd` suboption for post-write hooks.

For example, one can do
```ini
[post_write_hooks]
hooks = pre-commit

pre-commit.type = console_scripts
pre-commit.entrypoint = pre-commit
pre-commit.options = run --files REVISION_SCRIPT_FILENAME
pre-commit.cwd = %(here)s
```

This feature is illustrated by the last line above.

### Description

* Improve the names of some variables recently created in #820 in order to make the code more readable.
* Add `cwd` as an option which is passed directly into `subprocess.run()`
* Add a brief description to the documentation, together with an example with `pre-commit`.
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->



This pull request is:

A new feature implementation

- [X] please include the issue number, and create an issue if none exists, which must
- [X] include a complete example of how the feature would look.
- [X] Please include: `Fixes: #<issue number>` in the commit message
- [x] **please include tests.**

**Help requested:** I can't think of any simple way to write a test. Does anyone have a suggestion???