### PR TITLE
Add /pysqlite_test_schema.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage.xml
 .vscode/
 .pytest_cache/
 /docs/build/_build/
+/pysqlite_test_schema.db


### PR DESCRIPTION
Fixes #824

Running `tox` produces a `/pysqlite_test_schema.db` file which has been added to `.gitignore`.

### Description

Add `/pysqlite_test_schema.db` to `.gitignore`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

[None of the above.]