### PR TITLE
Add kwargs support to DropIndexOp autogenerate render

### DIFF
--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -240,6 +240,23 @@ class AutogenRenderTest(TestBase):
             "op.drop_index('test_active_code_idx', table_name='test')",
         )
 
+    @testing.emits_warning("Can't validate argument ")
+    def test_render_drop_index_custom_kwarg(self):
+        t = Table(
+            "test",
+            MetaData(),
+            Column("id", Integer, primary_key=True),
+            Column("active", Boolean()),
+            Column("code", String(255)),
+        )
+        idx = Index(None, t.c.active, t.c.code, somedialect_foobar="option")
+        op_obj = ops.DropIndexOp.from_index(idx)
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.drop_index(op.f('ix_test_active'), table_name='test', "
+            "somedialect_foobar='option')",
+        )
+
     def test_drop_index_batch(self):
         """
         autogenerate.render._drop_index


### PR DESCRIPTION
`DropIndexOp` does not render keyword arguments such as `postgresql_concurrently`.

### Description
Fixes https://github.com/sqlalchemy/alembic/issues/849

The fix is modeled after `CreateIndexOp` since these two constructs are very similar. Test is added in `test/test_autogen_render.py`, which, again, is similar to existing test `test_render_add_index_custom_kwarg`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
