### PR TITLE
Add async as template to docs

### DIFF
--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -106,6 +106,7 @@ command::
     Available templates:
 
     generic - Generic single-database configuration.
+    async - Generic single-database configuration with an async dbapi.
     multidb - Rudimentary multi-database configuration.
     pylons - Configuration that reads from a Pylons project environment.
 


### PR DESCRIPTION
It seems that latest version of alembic lists `async` as template

Add `async` template to `tutorial.rst`

### Description
Add `async` template to `tutorial.rst`


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
