### PR TITLE
Do not tag wheel as being compatible with Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,9 +67,6 @@ console_scripts =
 [egg_info]
 tag_build=dev
 
-[bdist_wheel]
-universal = 1
-
 [upload_docs]
 upload-dir = docs/build/output/html
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Since this project no longer supports Python < 3.6, wheels should
not be created with the "py2.py3" tag in their filename.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
