### PR TITLE
fix: typos in doc/build/api

### DIFF
--- a/docs/build/api/autogenerate.rst
+++ b/docs/build/api/autogenerate.rst
@@ -380,7 +380,7 @@ it runs.  The resulting migration structure would look like this::
 
 Given the above, the following guidelines should be considered when
 the ``env.py`` script calls upon :meth:`.MigrationContext.run_migrations`
-mutiple times when running autogenerate:
+multiple times when running autogenerate:
 
 * If the ``process_revision_directives`` hook aims to **add elements
   based on inspection of the current database /

--- a/docs/build/api/config.rst
+++ b/docs/build/api/config.rst
@@ -18,7 +18,7 @@ it is needed for the following use cases:
   with the actual script files in a migration environment
 * to create an :class:`.EnvironmentContext`, which allows you to
   actually run the ``env.py`` module within the migration environment
-* to programatically run any of the commands in the :ref:`alembic.command.toplevel`
+* to programmatically run any of the commands in the :ref:`alembic.command.toplevel`
   module.
 
 The :class:`.Config` is *not* needed for these cases:


### PR DESCRIPTION
Fix various typos under the doc/build/api section. Separate PR's, when time allows, will be pushed for other areas with typos.

### Description
This PR identified typos in the documentation using the codespell project with an updated dictionary from September 7th to locate the typos. Filters were used to avoid known "typos" such as selectin which are library-specific rather than actual typos.

X-Ref: https://github.com/codespell-project/codespell

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
You too!