### PR TITLE
Fixes #912: use underlying_type if available for tokenizing column type

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -435,7 +435,8 @@ class DefaultImpl(metaclass=ImplMeta):
                         )
 
     def _tokenize_column_type(self, column: "Column") -> Params:
-        definition = self.dialect.type_compiler.process(column.type).lower()
+        column_type = getattr(column.type, "underlying_type", column.type)
+        definition = self.dialect.type_compiler.process(column_type).lower()
 
         # tokenize the SQLAlchemy-generated version of a type, so that
         # the two can be compared.


### PR DESCRIPTION
I found no workaround for an exception I got, so prepared a PR instead.

### Description


I guess there should be a better fix as accessing the column type through shell contains the `length=150`:
```
>> MyModel.__table__.columns["credentials"].type
>> StringEncryptedType(length=150)
```
Not sure how to get it in `_tokenize_column_type`.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
