### PR TITLE
Fix constraint_name type of create_foreign_key

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -541,8 +541,8 @@ def create_foreign_key(
     off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
     construct is ultimately used to generate the ALTER statement.
 
-    :param name: Name of the foreign key constraint.  The name is necessary
-     so that an ALTER statement can be emitted.  For setups that
+    :param constraint_name: Name of the foreign key constraint.  The name is
+     necessary so that an ALTER statement can be emitted.  For setups that
      use an automated naming scheme such as that described at
      :ref:`sqla:constraint_naming_conventions`,
      ``name`` here can be ``None``, as the event listener will
@@ -643,8 +643,8 @@ def create_primary_key(
     off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
     construct is ultimately used to generate the ALTER statement.
 
-    :param name: Name of the primary key constraint.  The name is necessary
-     so that an ALTER statement can be emitted.  For setups that
+    :param constraint_name: Name of the primary key constraint.  The name is
+     necessary so that an ALTER statement can be emitted.  For setups that
      use an automated naming scheme such as that described at
      :ref:`sqla:constraint_naming_conventions`
      ``name`` here can be ``None``, as the event listener will
@@ -850,7 +850,7 @@ def drop_column(
     """
 
 def drop_constraint(
-    constraint_name: Optional[str],
+    constraint_name: str,
     table_name: str,
     type_: Optional[str] = None,
     schema: Optional[str] = None,
@@ -1002,7 +1002,7 @@ def execute(
        op.execute("INSERT INTO table (foo) VALUES ('\:colon_value')")
 
 
-    :param sql: Any legal SQLAlchemy expression, including:
+    :param sqltext: Any legal SQLAlchemy expression, including:
 
     * a string
     * a :func:`sqlalchemy.sql.expression.text` construct.

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -618,7 +618,7 @@ def create_index(
     """
 
 def create_primary_key(
-    constraint_name: str,
+    constraint_name: Optional[str],
     table_name: str,
     columns: List[str],
     schema: Optional[str] = None,

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -541,9 +541,9 @@ def create_foreign_key(
     off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
     construct is ultimately used to generate the ALTER statement.
 
-    :param constraint_name: Name of the foreign key constraint.  The name is
-     necessary so that an ALTER statement can be emitted.  For setups that
-     use an automated naming scheme such as that described at
+    :param constraint_name: Name of the foreign key constraint.  The name
+     is necessary so that an ALTER statement can be emitted.  For setups
+     that use an automated naming scheme such as that described at
      :ref:`sqla:constraint_naming_conventions`,
      ``name`` here can be ``None``, as the event listener will
      apply the name to the constraint object when it is associated
@@ -643,9 +643,9 @@ def create_primary_key(
     off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
     construct is ultimately used to generate the ALTER statement.
 
-    :param constraint_name: Name of the primary key constraint.  The name is
-     necessary so that an ALTER statement can be emitted.  For setups that
-     use an automated naming scheme such as that described at
+    :param constraint_name: Name of the primary key constraint.  The name
+     is necessary so that an ALTER statement can be emitted.  For setups
+     that use an automated naming scheme such as that described at
      :ref:`sqla:constraint_naming_conventions`
      ``name`` here can be ``None``, as the event listener will
      apply the name to the constraint object when it is associated

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -508,7 +508,7 @@ def create_exclude_constraint(
     """
 
 def create_foreign_key(
-    constraint_name: str,
+    constraint_name: Optional[str],
     source_table: str,
     referent_table: str,
     local_cols: List[str],
@@ -850,7 +850,7 @@ def drop_column(
     """
 
 def drop_constraint(
-    constraint_name: str,
+    constraint_name: Optional[str],
     table_name: str,
     type_: Optional[str] = None,
     schema: Optional[str] = None,

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -296,7 +296,7 @@ class CreatePrimaryKeyOp(AddConstraintOp):
     def create_primary_key(
         cls,
         operations: "Operations",
-        constraint_name: str,
+        constraint_name: Optional[str],
         table_name: str,
         columns: List[str],
         schema: Optional[str] = None,

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -588,7 +588,7 @@ class CreateForeignKeyOp(AddConstraintOp):
     def create_foreign_key(
         cls,
         operations: "Operations",
-        constraint_name: str,
+        constraint_name: Optional[str],
         source_table: str,
         referent_table: str,
         local_cols: List[str],

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -321,9 +321,9 @@ class CreatePrimaryKeyOp(AddConstraintOp):
         off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
         construct is ultimately used to generate the ALTER statement.
 
-        :param name: Name of the primary key constraint.  The name is necessary
-         so that an ALTER statement can be emitted.  For setups that
-         use an automated naming scheme such as that described at
+        :param constraint_name: Name of the primary key constraint.  The name
+         is necessary so that an ALTER statement can be emitted.  For setups
+         that use an automated naming scheme such as that described at
          :ref:`sqla:constraint_naming_conventions`
          ``name`` here can be ``None``, as the event listener will
          apply the name to the constraint object when it is associated
@@ -621,9 +621,9 @@ class CreateForeignKeyOp(AddConstraintOp):
         off normally.   The :class:`~sqlalchemy.schema.AddConstraint`
         construct is ultimately used to generate the ALTER statement.
 
-        :param name: Name of the foreign key constraint.  The name is necessary
-         so that an ALTER statement can be emitted.  For setups that
-         use an automated naming scheme such as that described at
+        :param constraint_name: Name of the foreign key constraint.  The name
+         is necessary so that an ALTER statement can be emitted.  For setups
+         that use an automated naming scheme such as that described at
          :ref:`sqla:constraint_naming_conventions`,
          ``name`` here can be ``None``, as the event listener will
          apply the name to the constraint object when it is associated
@@ -2389,7 +2389,7 @@ class ExecuteSQLOp(MigrateOperation):
            op.execute("INSERT INTO table (foo) VALUES ('\:colon_value')")
 
 
-        :param sql: Any legal SQLAlchemy expression, including:
+        :param sqltext: Any legal SQLAlchemy expression, including:
 
         * a string
         * a :func:`sqlalchemy.sql.expression.text` construct.


### PR DESCRIPTION
Make the type of contraint_name optional in create_foreign_key

### Description
- Make the type of `contraint_name` optional in `create_foreign_key` as stated in the documentation (passing `None` will auto-generate a constraint name).
- Fixes some typos/inconsistencies in documentation.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
