### PR TITLE
Adds exception when trying to run write_pyi.py with Python < 3.9

### DIFF
--- a/docs/build/requirements.txt
+++ b/docs/build/requirements.txt
@@ -4,3 +4,5 @@ git+https://github.com/sqlalchemy/sqlalchemy.git
 python-dateutil
 # because there's a dependency in pyfiles.py
 Mako
+importlib-metadata;python_version<"3.8"
+importlib-resources;python_version<"3.9"

--- a/tools/write_pyi.py
+++ b/tools/write_pyi.py
@@ -36,7 +36,7 @@ def generate_pyi_for_proxy(
     ignore_output: bool,
     ignore_items: set,
 ):
-    if not sys.version_info >= (3, 9):
+    if sys.version_info < (3, 9):
         raise RuntimeError("This script must be run with Python 3.9 or higher")
 
     # When using an absolute path on windows, this will generate the correct

--- a/tools/write_pyi.py
+++ b/tools/write_pyi.py
@@ -9,7 +9,7 @@ from mako.pygen import PythonPrinter
 
 sys.path.append(str(Path(__file__).parent.parent))
 
-if True:  # avoid flake/zimports missing with the order
+if True:  # avoid flake/zimports messing with the order
     from alembic.operations.base import Operations
     from alembic.runtime.environment import EnvironmentContext
     from alembic.script.write_hooks import console_scripts
@@ -36,6 +36,13 @@ def generate_pyi_for_proxy(
     ignore_output: bool,
     ignore_items: set,
 ):
+    if not sys.version_info >= (3, 9):
+        raise RuntimeError("This script must be run with Python 3.9 or higher")
+
+    # When using an absolute path on windows, this will generate the correct
+    # relative path that shall be written to the top comment of the pyi file.
+    if Path(progname).is_absolute():
+        progname = Path(progname).relative_to(Path().cwd()).as_posix()
 
     imports = []
     read_imports = False
@@ -154,15 +161,15 @@ def run_file(
     else:
         with NamedTemporaryFile(delete=False, suffix=".pyi") as f:
             f.close()
+            f_path = Path(f.name)
             generate_pyi_for_proxy(
                 cls_to_generate,
                 progname,
                 source_path=source_path,
-                destination_path=f.name,
+                destination_path=f_path,
                 ignore_output=True,
                 ignore_items=ignore_items,
             )
-            f_path = Path(f.name)
             sys.stdout.write(f_path.read_text())
         f_path.unlink()
 


### PR DESCRIPTION
### Description
write_pyi.py now raises an exception when someone tries to run the script with Python version 3.8 or smaller.

This also fixes:
- When using absolute Paths, i.e. on Windows, they are now converted to relative paths to avoid useless changes in the doc strings of the pyi files
- Corrected destination_path argument type when calling `generate_pyi_for_proxy` in `run_file`
- A comment typo

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
