### PR TITLE
Add new ensure_version command

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -643,3 +643,32 @@ def edit(config: "Config", rev: str) -> None:
             )
         for sc in revs:
             util.open_in_editor(sc.path)
+
+
+def ensure_version(
+    config: "Config",
+    sql: bool = False,
+) -> None:
+    """Create the alembic version table if it doesn't exist already .
+
+    :param config: a :class:`.Config` instance.
+
+    :param sql: use ``--sql`` mode
+
+     .. versionadded:: 1.8
+
+    """
+
+    script = ScriptDirectory.from_config(config)
+
+    def do_ensure_version(rev, context):
+        context._ensure_version_table()
+        return []
+
+    with EnvironmentContext(
+        config,
+        script,
+        fn=do_ensure_version,
+        as_sql=sql,
+    ):
+        script.run_env()

--- a/docs/build/unreleased/964.rst
+++ b/docs/build/unreleased/964.rst
@@ -1,0 +1,5 @@
+.. change::
+    :tags: feature, commands
+    :tickets: 964
+
+    Add a new command "ensure_version" which creates the alembic version table

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1185,3 +1185,34 @@ class CommandLineTest(TestBase):
 
         is_true("test_prog" in str(buf.getvalue()))
         is_true(__version__ in str(buf.getvalue()))
+
+
+class EnureVersionTest(TestBase):
+    @classmethod
+    def setup_class(cls):
+        cls.bind = _sqlite_file_db()
+        cls.cfg = _sqlite_testing_config()
+
+    @classmethod
+    def teardown_class(cls):
+        clear_staging_env()
+
+    def test_ensure_version(self):
+        command.ensure_version(self.cfg)
+        engine = self.bind
+        with engine.connect() as conn:
+            is_true(_connectable_has_table(conn, "alembic_version", None))
+
+    def test_ensure_version_called_twice(self):
+        command.ensure_version(self.cfg)
+        command.ensure_version(self.cfg)
+
+        engine = self.bind
+        with engine.connect() as conn:
+            is_true(_connectable_has_table(conn, "alembic_version", None))
+
+    def test_sql_ensure_version(self):
+        with capture_context_buffer() as buf:
+            command.ensure_version(self.cfg, sql=True)
+
+        is_true(buf.getvalue().startswith("CREATE TABLE alembic_version"))

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1191,6 +1191,7 @@ class EnureVersionTest(TestBase):
     @classmethod
     def setup_class(cls):
         cls.bind = _sqlite_file_db()
+        cls.env = staging_env()
         cls.cfg = _sqlite_testing_config()
 
     @classmethod


### PR DESCRIPTION
Closes #964

### Description
Add a new command which creates the alembic_version table. Basically this was possible before by combining stamp and heads but was not nice to use. Using pure stamp is not possible.
Basically, the command does just call the` _ensure_version_table` method which existed before.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [X] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
