### PR TITLE
Update documentation about alembic configuration path

### DIFF
--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -118,9 +118,9 @@ Editing the .ini File
 =====================
 
 Alembic placed a file ``alembic.ini`` into the current directory.  This is a file that the ``alembic``
-script looks for when invoked.  This file can be anywhere, either in the same directory
-from which the ``alembic`` script will normally be invoked, or if in a different directory, can
-be specified by using the ``--config`` option to the ``alembic`` runner.
+script looks for when invoked.  This file can exist in a different directory, with the location to it
+specified by either the ``--config`` option for the ``alembic`` runner or the ``ALEMBIC_CONFIG``
+environment variable (the former takes precedence).
 
 The file generated with the "generic" configuration looks like::
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This PR adds information to the tutorial page regarding the `ALEMBIC_CONFIG` variable which was made available in b12f31b (and described in #608). This should hopefully make it more clear to first-time users what options are available for setting the path to the configuration file.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
