### PR TITLE
Tweak docs about version_path_separator

### DIFF
--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -35,16 +35,18 @@ prepend_sys_path = .
 # version location specification; This defaults
 # to ${script_location}/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path.
-# The path separator used here should be the separator specified by "version_path_separator"
+# The path separator used here should be the separator specified by "version_path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:${script_location}/versions
 
 # version path separator; As mentioned above, this is the character used to split
-# version_locations. Valid values are:
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
 #
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # default: use os.pathsep
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -35,16 +35,18 @@ prepend_sys_path = .
 # version location specification; This defaults
 # to ${script_location}/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path.
-# The path separator used here should be the separator specified by "version_path_separator"
+# The path separator used here should be the separator specified by "version_path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:${script_location}/versions
 
 # version path separator; As mentioned above, this is the character used to split
-# version_locations. Valid values are:
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
 #
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # default: use os.pathsep
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -35,16 +35,18 @@ prepend_sys_path = .
 # version location specification; This defaults
 # to ${script_location}/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path.
-# The path separator used here should be the separator specified by "version_path_separator"
+# The path separator used here should be the separator specified by "version_path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:${script_location}/versions
 
 # version path separator; As mentioned above, this is the character used to split
-# version_locations. Valid values are:
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
 #
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # default: use os.pathsep
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/alembic/templates/pylons/alembic.ini.mako
+++ b/alembic/templates/pylons/alembic.ini.mako
@@ -35,16 +35,18 @@ prepend_sys_path = .
 # version location specification; This defaults
 # to ${script_location}/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path.
-# The path separator used here should be the separator specified by "version_path_separator"
+# The path separator used here should be the separator specified by "version_path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:${script_location}/versions
 
 # version path separator; As mentioned above, this is the character used to split
-# version_locations. Valid values are:
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
 #
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # default: use os.pathsep
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/docs/build/branches.rst
+++ b/docs/build/branches.rst
@@ -521,11 +521,12 @@ that module.  So to start out, we can edit ``alembic.ini`` to refer
 to multiple directories;  we'll also state the current ``versions``
 directory as one of them::
 
+  # A separator for the location paths must be defined first.
+  version_path_separator = os  # Use os.pathsep.
   # version location specification; this defaults
   # to foo/versions.  When using multiple version
   # directories, initial revisions must be specified with --version-path
-  version_path_separator = space
-  version_locations = %(here)s/model/networking %(here)s/alembic/versions
+  version_locations = %(here)s/model/networking:%(here)s/alembic/versions
 
 The new directory ``%(here)s/model/networking`` is in terms of where
 the ``alembic.ini`` file is, as we are using the symbol ``%(here)s`` which

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -162,16 +162,18 @@ The file generated with the "generic" configuration looks like::
     # version location specification; This defaults
     # to ${script_location}/versions.  When using multiple version
     # directories, initial revisions must be specified with --version-path.
-    # The path separator used here should be the separator specified by "version_path_separator"
+    # The path separator used here should be the separator specified by "version_path_separator" below.
     # version_locations = %(here)s/bar:%(here)s/bat:${script_location}/versions
 
     # version path separator; As mentioned above, this is the character used to split
-    # version_locations. Valid values are:
+    # version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+    # If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+    # Valid values for version_path_separator are:
     #
     # version_path_separator = :
     # version_path_separator = ;
     # version_path_separator = space
-    version_path_separator = os  # default: use os.pathsep
+    version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
     # the output encoding used when revision files
     # are written from script.py.mako
@@ -305,6 +307,10 @@ This file contains the following features:
 
 * ``version_locations`` - an optional list of revision file locations, to
   allow revisions to exist in multiple directories simultaneously.
+  See :ref:`multiple_bases` for examples.
+
+* ``version_path_separator`` - a separator of ``version_locations`` paths.
+  It should be defined if multiple ``version_locations`` is used.
   See :ref:`multiple_bases` for examples.
 
 * ``output_encoding`` - the encoding to use when Alembic writes the


### PR DESCRIPTION
I tried to improve docs regarding `version_path_separator` based on my experience with it.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
