### PR TITLE
Fix duplicated constraints when using expressions

### DIFF
--- a/alembic/operations/schemaobj.py
+++ b/alembic/operations/schemaobj.py
@@ -214,7 +214,8 @@ class SchemaObjects:
 
         constraints = [
             sqla_compat._copy(elem, target_table=t)
-            if getattr(elem, "parent", None) is not None
+            if getattr(elem, "parent", None) is not t
+            and getattr(elem, "parent", None) is not None
             else elem
             for elem in columns
             if isinstance(elem, (Constraint, Index))

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -882,6 +882,27 @@ class OpTest(TestBase):
         ck = [c for c in t1.constraints if isinstance(c, CheckConstraint)]
         eq_(ck[0].name, "ck_1")
 
+    def test_create_table_with_check_constraint_with_expr(self):
+        context = op_fixture()
+        foo_id = Column("foo_id", Integer)
+        t1 = op.create_table(
+            "some_table",
+            Column("id", Integer, primary_key=True),
+            foo_id,
+            CheckConstraint(foo_id > 5, name="ck_1"),
+        )
+        context.assert_(
+            "CREATE TABLE some_table ("
+            "id INTEGER NOT NULL, "
+            "foo_id INTEGER, "
+            "PRIMARY KEY (id), "
+            "CONSTRAINT ck_1 CHECK (foo_id > 5))"
+        )
+
+        ck = [c for c in t1.constraints if isinstance(c, CheckConstraint)]
+        eq_(ck[0].name, "ck_1")
+        eq_(len(ck), 1)
+
     def test_create_table_unique_constraint(self):
         context = op_fixture()
         t1 = op.create_table(


### PR DESCRIPTION
Fix for issue #1004 

### Description

When using expressions in the construction of constraints, the constraints end-up being duplicated in the DDL emitted by Alembic.

Added a non-regression test, but I am not sure it's the best way/place to test the issue. Indeed the issue is in the `SchemaObjects.table()` method, but I couldn't find tests that test it directly. They are always compounded with tests on the functions from the `op` module. Anyhow, did my best to replicate the current logic.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
