### PR TITLE
Add epoch as an option for file_template

### DIFF
--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -782,8 +782,7 @@ class ScriptDirectory:
         message: Optional[str],
         create_date: "datetime.datetime",
     ) -> str:
-        epoch_reference_date = datetime.datetime(1970, 1, 1)
-        epoch = int((create_date - epoch_reference_date).total_seconds())
+        epoch = int(create_date.timestamp())
         slug = "_".join(_slug_re.findall(message or "")).lower()
         if len(slug) > self.truncate_slug_length:
             slug = slug[: self.truncate_slug_length].rsplit("_", 1)[0] + "_"

--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -782,6 +782,8 @@ class ScriptDirectory:
         message: Optional[str],
         create_date: "datetime.datetime",
     ) -> str:
+        epoch_reference_date = datetime.datetime(1970, 1, 1)
+        epoch = int((create_date - epoch_reference_date).total_seconds())
         slug = "_".join(_slug_re.findall(message or "")).lower()
         if len(slug) > self.truncate_slug_length:
             slug = slug[: self.truncate_slug_length].rsplit("_", 1)[0] + "_"
@@ -790,6 +792,7 @@ class ScriptDirectory:
             % {
                 "rev": rev_id,
                 "slug": slug,
+                "epoch": epoch,
                 "year": create_date.year,
                 "month": create_date.month,
                 "day": create_date.day,

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -274,6 +274,7 @@ This file contains the following features:
 
     * ``%%(rev)s`` - revision id
     * ``%%(slug)s`` - a truncated string derived from the revision message
+    * ``%%(epoch)s`` - epoch timestamp based on the create date
     * ``%%(year)d``, ``%%(month).2d``, ``%%(day).2d``, ``%%(hour).2d``,
       ``%%(minute).2d``, ``%%(second).2d`` - components of the create date,
       by default ``datetime.datetime.now()`` unless the ``timezone``

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -184,6 +184,44 @@ class ScriptNamingTest(TestBase):
                 "message_2012_7_25_15_8_5.py" % _get_staging_directory()
             ),
         )
+    
+    def test_epoch_name(self):
+        script = ScriptDirectory(
+            _get_staging_directory(),
+            file_template="%(epoch)s_%(rev)s_%(slug)s_"
+            "%(year)s_%(month)s_"
+            "%(day)s_%(hour)s_"
+            "%(minute)s_%(second)s",
+        )
+        create_date = datetime.datetime(2012, 7, 25, 15, 8, 5)
+        eq_(
+            script._rev_path(
+                script.versions, "12345", "this is a message", create_date
+            ),
+            os.path.abspath(
+                "%s/versions/1343228885_12345_this_is_a_"
+                "message_2012_7_25_15_8_5.py" % _get_staging_directory()
+            ),
+        )
+    
+    def test_epoch_formula(self):
+        script = ScriptDirectory(
+            _get_staging_directory(),
+            file_template="%(epoch)s_%(rev)s_%(slug)s_"
+            "%(year)s_%(month)s_"
+            "%(day)s_%(hour)s_"
+            "%(minute)s_%(second)s",
+        )
+        create_date = datetime.datetime(2012, 7, 25, 15, 8, 6)
+        eq_(
+            script._rev_path(
+                script.versions, "12345", "this is a message", create_date
+            ),
+            os.path.abspath(
+                "%s/versions/1343228886_12345_this_is_a_"
+                "message_2012_7_25_15_8_6.py" % _get_staging_directory()
+            ),
+        )
 
     def _test_tz(self, timezone_arg, given, expected):
         script = ScriptDirectory(

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -199,7 +199,7 @@ class ScriptNamingTest(TestBase):
                 script.versions, "12345", "this is a message", create_date
             ),
             os.path.abspath(
-                "%s/versions/1343228885_12345_this_is_a_"
+                "%s/versions/1343239685_12345_this_is_a_"
                 "message_2012_7_25_15_8_5.py" % _get_staging_directory()
             ),
         )
@@ -218,7 +218,7 @@ class ScriptNamingTest(TestBase):
                 script.versions, "12345", "this is a message", create_date
             ),
             os.path.abspath(
-                "%s/versions/1343228886_12345_this_is_a_"
+                "%s/versions/1343239686_12345_this_is_a_"
                 "message_2012_7_25_15_8_6.py" % _get_staging_directory()
             ),
         )

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -193,13 +193,13 @@ class ScriptNamingTest(TestBase):
             "%(day)s_%(hour)s_"
             "%(minute)s_%(second)s",
         )
-        create_date = datetime.datetime(2012, 7, 25, 15, 8, 5)
+        create_date = datetime.datetime(2012, 7, 25, 15, 8, 5, tzinfo=tz.gettz("UTC"))
         eq_(
             script._rev_path(
                 script.versions, "12345", "this is a message", create_date
             ),
             os.path.abspath(
-                "%s/versions/1343239685_12345_this_is_a_"
+                "%s/versions/1343228885_12345_this_is_a_"
                 "message_2012_7_25_15_8_5.py" % _get_staging_directory()
             ),
         )
@@ -212,13 +212,13 @@ class ScriptNamingTest(TestBase):
             "%(day)s_%(hour)s_"
             "%(minute)s_%(second)s",
         )
-        create_date = datetime.datetime(2012, 7, 25, 15, 8, 6)
+        create_date = datetime.datetime(2012, 7, 25, 15, 8, 6, tzinfo=tz.gettz("UTC"))
         eq_(
             script._rev_path(
                 script.versions, "12345", "this is a message", create_date
             ),
             os.path.abspath(
-                "%s/versions/1343239686_12345_this_is_a_"
+                "%s/versions/1343228886_12345_this_is_a_"
                 "message_2012_7_25_15_8_6.py" % _get_staging_directory()
             ),
         )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Hi all, as we are not huge fans of big file names, we would rather use epoch as a way to have the migrations in chronological order. I made a small change (with docs and test) to allow the epoch to be used in the `file_template`. From what I could see, this shouldn't have many side effects. As this is my first PR around here, please let me know if there's anything that I should do differently. 

### Description
- Added epoch as an option to the `file_template`.
- Added a test to make sure the epoch is considered on the name
- Added a test to make sure the epoch formula is correct (one extra second increases epoch by 1)

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
- [ ] A short code fix
- [x] A new feature implementation
	- Fixes: #1027

