### PR TITLE
Fix #1050 - docs(cookbook): add note on including info object on declarative tables

### DIFF
--- a/docs/build/cookbook.rst
+++ b/docs/build/cookbook.rst
@@ -1150,6 +1150,12 @@ causes Alembic to treat them as tables in need of creation and to generate spuri
 
     my_view = Table('my_view', metadata, autoload=True, info=dict(is_view=True))    # Flag this as a view
 
+Or, if you use declarative tables::
+
+    class MyView(Base):
+        __tablename__ = 'my_view'
+        __table_args__ = {'info': {'is_view': True}} # Flag this as a view
+
 Then define ``include_object`` as::
 
     def include_object(object, name, type_, reflected, compare_to):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes #1050 - Adds instructions for including an info object on a declarative table for [Don’t emit CREATE TABLE statements for Views](https://alembic.sqlalchemy.org/en/latest/cookbook.html#don-t-emit-create-table-statements-for-views).

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
