### PR TITLE
Postgresql autogenterate: allow for index operators (such as inet_ops)

### DIFF
--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -248,7 +248,7 @@ class PostgresqlImpl(DefaultImpl):
             for expr in exprs:
                 while isinstance(expr, UnaryExpression):
                     expr = expr.element
-                if not isinstance(expr, Column):
+                if not isinstance(expr, ColumnClause):
                     if sqla_compat.sqla_2:
                         msg = ""
                     else:


### PR DESCRIPTION
This change is so that a Postgresql  index operators (such as inet_ops) gets autogenterated. It does so by broadening the types of index expression allowed from `Column` -> `ColumnClause`.

Fixes: #1098

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #1098` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
