### PR TITLE
add check command for upgrade diffs

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+
 def list_templates(config):
     """List available templates.
 
@@ -245,7 +246,8 @@ def revision(
 def check(
     config: "Config",
 ) -> None:
-    """Checks if the revision command with autogenerate has pending upgrade ops to run.
+    """Checks if the revision command with autogenerate has pending upgrade
+    ops to run.
 
     :param config: a :class:`.Config` object.
 
@@ -289,9 +291,11 @@ def check(
     migration_script = revision_context.generated_revisions[-1]
     diffs = migration_script.upgrade_ops.as_diffs()
     if diffs:
-        raise util.RevisionOpsNotEmptyError(f"Revision has upgrade ops to run: {diffs}.")
+        raise util.RevisionOpsNotEmptyError(
+            f"Revision has upgrade ops to run: {diffs}."
+        )
     else:
-        log.info("Revision has no upgrade ops to run.")   
+        log.info("Revision has no upgrade ops to run.")
 
 
 def merge(

--- a/alembic/command.py
+++ b/alembic/command.py
@@ -244,7 +244,7 @@ def revision(
 
 def check(
     config: "Config",
-) -> Union[Optional["Script"], List[Optional["Script"]]]:
+) -> None:
     """Checks if the revision command with autogenerate has pending upgrade ops to run.
 
     :param config: a :class:`.Config` object.

--- a/alembic/command.py
+++ b/alembic/command.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from typing import Callable
 from typing import List
@@ -17,7 +16,6 @@ if TYPE_CHECKING:
     from alembic.config import Config
     from alembic.script.base import Script
 
-log = logging.getLogger(__name__)
 
 def list_templates(config):
     """List available templates.
@@ -127,7 +125,6 @@ def revision(
     rev_id: Optional[str] = None,
     depends_on: Optional[str] = None,
     process_revision_directives: Callable = None,
-    check: bool = False,
 ) -> Union[Optional["Script"], List[Optional["Script"]]]:
     """Create a new revision file.
 
@@ -235,22 +232,12 @@ def revision(
         # these could theoretically be further processed / rewritten *here*,
         # in addition to the hooks present within each run_migrations() call,
         # or at the end of env.py run_migrations_online().
-    
-    if check:
-        if not autogenerate:
-            util.err("check flag cannot be used without autogenerate flag.")
-        migration_script = revision_context.generated_revisions[-1]
-        diffs = migration_script.upgrade_ops.as_diffs()
-        if diffs:
-            util.err(f"Revision has upgrade ops to run: {diffs}.")
-        else:
-            log.info("Revision has no upgrade ops to run.")      
+
+    scripts = [script for script in revision_context.generate_scripts()]
+    if len(scripts) == 1:
+        return scripts[0]
     else:
-        scripts = [script for script in revision_context.generate_scripts()]
-        if len(scripts) == 1:
-            return scripts[0]
-        else:
-            return scripts
+        return scripts
 
 
 def merge(

--- a/alembic/command.py
+++ b/alembic/command.py
@@ -172,10 +172,6 @@ def revision(
      the other parameters, this option is only available via programmatic
      use of :func:`.command.revision`
 
-    :param check: instead of generating a revision, checks if this revision
-     will contain upgrade ops; no new ops will have no action; new ops will
-     error; this is the ``--check`` option to ``alembic revision``.
-
     """
 
     script_directory = ScriptDirectory.from_config(config)
@@ -242,13 +238,11 @@ def revision(
     
     if check:
         if not autogenerate:
-            raise util.CommandError(
-                "Check flag cannot be used without autogenerate flag"
-            )
+            util.err("check flag cannot be used without autogenerate flag.")
         migration_script = revision_context.generated_revisions[-1]
         diffs = migration_script.upgrade_ops.as_diffs()
         if diffs:
-            raise util.RevisionOpsNotEmptyError(f"Revision has upgrade ops to run: {diffs}.")
+            util.err(f"Revision has upgrade ops to run: {diffs}.")
         else:
             log.info("Revision has no upgrade ops to run.")      
     else:

--- a/alembic/command.py
+++ b/alembic/command.py
@@ -172,6 +172,10 @@ def revision(
      the other parameters, this option is only available via programmatic
      use of :func:`.command.revision`
 
+    :param check: instead of generating a revision, checks if this revision
+     will contain upgrade ops; no new ops will have no action; new ops will
+     error; this is the ``--check`` option to ``alembic revision``.
+
     """
 
     script_directory = ScriptDirectory.from_config(config)
@@ -238,11 +242,13 @@ def revision(
     
     if check:
         if not autogenerate:
-            util.err("check flag cannot be used without autogenerate flag.")
+            raise util.CommandError(
+                "Check flag cannot be used without autogenerate flag"
+            )
         migration_script = revision_context.generated_revisions[-1]
         diffs = migration_script.upgrade_ops.as_diffs()
         if diffs:
-            util.err(f"Revision has upgrade ops to run: {diffs}.")
+            raise util.RevisionOpsNotEmptyError(f"Revision has upgrade ops to run: {diffs}.")
         else:
             log.info("Revision has no upgrade ops to run.")      
     else:

--- a/alembic/command.py
+++ b/alembic/command.py
@@ -246,8 +246,7 @@ def revision(
 def check(
     config: "Config",
 ) -> None:
-    """Checks if the revision command with autogenerate has pending upgrade
-    ops to run.
+    """Check if revision command with autogenerate has pending upgrade ops.
 
     :param config: a :class:`.Config` object.
 

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -420,15 +420,6 @@ class CommandLine:
                         "of database to model.",
                     ),
                 ),
-                "check": (
-                    "--check",
-                    dict(
-                        action="store_true",
-                        help="Check if revision script will have "
-                        "candidate migration operations, based on "
-                        "comparison of database to model.",
-                    ),
-                ),
                 "rev_range": (
                     "-r",
                     "--rev-range",

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -420,6 +420,15 @@ class CommandLine:
                         "of database to model.",
                     ),
                 ),
+                "check": (
+                    "--check",
+                    dict(
+                        action="store_true",
+                        help="Check if revision script will have "
+                        "candidate migration operations, based on "
+                        "comparison of database to model.",
+                    ),
+                ),
                 "rev_range": (
                     "-r",
                     "--rev-range",

--- a/alembic/util/__init__.py
+++ b/alembic/util/__init__.py
@@ -1,5 +1,5 @@
 from .editor import open_in_editor
-from .exc import CommandError
+from .exc import CommandError, RevisionOpsNotEmptyError
 from .langhelpers import _with_legacy_names
 from .langhelpers import asbool
 from .langhelpers import dedupe_tuple

--- a/alembic/util/__init__.py
+++ b/alembic/util/__init__.py
@@ -1,5 +1,6 @@
 from .editor import open_in_editor
-from .exc import CommandError, RevisionOpsNotEmptyError
+from .exc import CommandError
+from .exc import RevisionOpsNotEmptyError
 from .langhelpers import _with_legacy_names
 from .langhelpers import asbool
 from .langhelpers import dedupe_tuple

--- a/alembic/util/__init__.py
+++ b/alembic/util/__init__.py
@@ -1,5 +1,5 @@
 from .editor import open_in_editor
-from .exc import CommandError, RevisionOpsNotEmptyError
+from .exc import CommandError
 from .langhelpers import _with_legacy_names
 from .langhelpers import asbool
 from .langhelpers import dedupe_tuple

--- a/alembic/util/exc.py
+++ b/alembic/util/exc.py
@@ -1,5 +1,2 @@
 class CommandError(Exception):
     pass
-
-class RevisionOpsNotEmptyError(Exception):
-    pass

--- a/alembic/util/exc.py
+++ b/alembic/util/exc.py
@@ -1,5 +1,6 @@
 class CommandError(Exception):
     pass
 
+
 class RevisionOpsNotEmptyError(Exception):
     pass

--- a/alembic/util/exc.py
+++ b/alembic/util/exc.py
@@ -1,2 +1,5 @@
 class CommandError(Exception):
     pass
+
+class RevisionOpsNotEmptyError(Exception):
+    pass

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,7 +8,7 @@ import re
 from typing import cast
 
 from sqlalchemy import exc as sqla_exc
-from sqlalchemy import VARCHAR, text
+from sqlalchemy import text, VARCHAR
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.schema import Column
 
@@ -579,13 +579,14 @@ finally:
 
     def test_check_no_changes(self):
         self._env_fixture()
-        command.check(self.cfg) # no problem
+        command.check(self.cfg)  # no problem
 
     def test_check_changes_detected(self):
         self._env_fixture()
         with mock.patch(
             "alembic.operations.ops.UpgradeOps.as_diffs",
-            return_value=[('remove_column', None, 'foo', Column('old_data', VARCHAR()))]
+            return_value=[('remove_column', None, 'foo',
+                           Column('old_data', VARCHAR()))]
         ):
             assert_raises_message(
                 util.RevisionOpsNotEmptyError,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,7 +8,8 @@ import re
 from typing import cast
 
 from sqlalchemy import exc as sqla_exc
-from sqlalchemy import text, VARCHAR
+from sqlalchemy import text
+from sqlalchemy import VARCHAR
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.schema import Column
 
@@ -585,8 +586,9 @@ finally:
         self._env_fixture()
         with mock.patch(
             "alembic.operations.ops.UpgradeOps.as_diffs",
-            return_value=[('remove_column', None, 'foo',
-                           Column('old_data', VARCHAR()))]
+            return_value=[
+                ("remove_column", None, "foo", Column("old_data", VARCHAR()))
+            ],
         ):
             assert_raises_message(
                 util.RevisionOpsNotEmptyError,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,8 +8,9 @@ import re
 from typing import cast
 
 from sqlalchemy import exc as sqla_exc
-from sqlalchemy import text
+from sqlalchemy import VARCHAR, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql.schema import Column
 
 from alembic import __version__
 from alembic import command
@@ -537,6 +538,61 @@ finally:
         self._env_fixture()
         self.cfg.set_main_option("revision_environment", "true")
         command.revision(self.cfg, sql=True)
+
+
+class CheckTest(TestBase):
+    def setUp(self):
+        self.env = staging_env()
+        self.cfg = _sqlite_testing_config()
+
+    def tearDown(self):
+        clear_staging_env()
+
+    def _env_fixture(self, version_table_pk=True):
+        env_file_fixture(
+            """
+
+from sqlalchemy import MetaData, engine_from_config
+target_metadata = MetaData()
+
+engine = engine_from_config(
+    config.get_section(config.config_ini_section),
+    prefix='sqlalchemy.')
+
+connection = engine.connect()
+
+context.configure(
+    connection=connection, target_metadata=target_metadata,
+    version_table_pk=%r
+)
+
+try:
+    with context.begin_transaction():
+        context.run_migrations()
+finally:
+    connection.close()
+    engine.dispose()
+
+"""
+            % (version_table_pk,)
+        )
+
+    def test_check_no_changes(self):
+        self._env_fixture()
+        command.check(self.cfg) # no problem
+
+    def test_check_changes_detected(self):
+        self._env_fixture()
+        with mock.patch(
+            "alembic.operations.ops.UpgradeOps.as_diffs",
+            return_value=[('remove_column', None, 'foo', Column('old_data', VARCHAR()))]
+        ):
+            assert_raises_message(
+                util.RevisionOpsNotEmptyError,
+                "Revision has upgrade ops to run:",
+                command.check,
+                self.cfg,
+            )
 
 
 class _StampTest:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,9 +8,8 @@ import re
 from typing import cast
 
 from sqlalchemy import exc as sqla_exc
-from sqlalchemy import VARCHAR, text
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
-from sqlalchemy.sql.schema import Column
 
 from alembic import __version__
 from alembic import command
@@ -386,36 +385,6 @@ finally:
             self.cfg,
             autogenerate=True,
         )
-  
-    def test_rev_check_with_no_autogen(self):
-        self._env_fixture()
-        assert_raises_message(
-            util.CommandError,
-            "Check flag cannot be used without autogenerate flag",
-            command.revision,
-            self.cfg,
-            autogenerate=False,
-            check=True,
-        )
-
-    def test_rev_autogen_check_no_changes(self):
-        self._env_fixture()
-        command.revision(self.cfg, autogenerate=True, check=True) # no problem
-
-    def test_rev_autogen_check_changes_detected(self):
-        self._env_fixture()
-        with mock.patch(
-            "alembic.operations.ops.UpgradeOps.as_diffs",
-            return_value=[('remove_column', None, 'foo', Column('old_data', VARCHAR()))]
-        ):
-            assert_raises_message(
-                util.RevisionOpsNotEmptyError,
-                "Revision has upgrade ops to run:",
-                command.revision,
-                self.cfg,
-                autogenerate=True,
-                check=True,
-            )
 
     def test_pk_constraint_normally_prevents_dupe_rows(self):
         self._env_fixture()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,8 +8,9 @@ import re
 from typing import cast
 
 from sqlalchemy import exc as sqla_exc
-from sqlalchemy import text
+from sqlalchemy import VARCHAR, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql.schema import Column
 
 from alembic import __version__
 from alembic import command
@@ -385,6 +386,36 @@ finally:
             self.cfg,
             autogenerate=True,
         )
+  
+    def test_rev_check_with_no_autogen(self):
+        self._env_fixture()
+        assert_raises_message(
+            util.CommandError,
+            "Check flag cannot be used without autogenerate flag",
+            command.revision,
+            self.cfg,
+            autogenerate=False,
+            check=True,
+        )
+
+    def test_rev_autogen_check_no_changes(self):
+        self._env_fixture()
+        command.revision(self.cfg, autogenerate=True, check=True) # no problem
+
+    def test_rev_autogen_check_changes_detected(self):
+        self._env_fixture()
+        with mock.patch(
+            "alembic.operations.ops.UpgradeOps.as_diffs",
+            return_value=[('remove_column', None, 'foo', Column('old_data', VARCHAR()))]
+        ):
+            assert_raises_message(
+                util.RevisionOpsNotEmptyError,
+                "Revision has upgrade ops to run:",
+                command.revision,
+                self.cfg,
+                autogenerate=True,
+                check=True,
+            )
 
     def test_pk_constraint_normally_prevents_dupe_rows(self):
         self._env_fixture()


### PR DESCRIPTION
Fixes #724 

### Description
* Add `check` command. If the revision command with autogenerate has pending upgrade operations to run, then raise an error. Otherwise, continue.

### Testing
#### Wrote Tests:
tox tests/test_command.py::CheckTest::test_check_no_changes
tox tests/test_command.py::CheckTest::test_check_changes_detected

#### I also tested this function in my company Replica's code base:
```
from alembic.config import Config
from alembic.command import check

def test_migration_autogen_parity():
    alembic_cfg = Config("alembic.ini")
    check(alembic_cfg)
```
1. When there is parity, the test passes.
2. When I spike a model with an extra change and then run the test, the error is thrown:
```
>           raise util.RevisionOpsNotEmptyError(f"Revision has upgrade ops to run: {diffs}.")
E           alembic.util.exc.RevisionOpsNotEmptyError: Revision has upgrade ops to run: [('add_column', 'schema_name', 'table_name', Column('new_column_name', TEXT(), table=<table_name>))].

.venv/lib/python3.10/site-packages/alembic/command.py:292: RevisionOpsNotEmptyError
...
Results (16.42s):
       1 failed
         - migrations/test_migration_autogen_parity.py:7 test_migration_autogen_parity
```

**Have a nice day!**
