### PR TITLE
Fix type annotation in `op.create_table_comment`

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -751,7 +751,7 @@ def create_table(
 def create_table_comment(
     table_name: str,
     comment: Optional[str],
-    existing_comment: None = None,
+    existing_comment: Optional[str] = None,
     schema: Optional[str] = None,
 ) -> Optional[Table]:
     """Emit a COMMENT ON operation to set the comment for a table.


### PR DESCRIPTION
### Description

The `existing_comment` parameter had type `None`, but it should be `Optional[str]`.

Fixes #903

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
