### PR TITLE
Include missing part of env.py

### DIFF
--- a/docs/build/cookbook.rst
+++ b/docs/build/cookbook.rst
@@ -1562,6 +1562,12 @@ together, and ``env.py`` as follows works::
         else:
             do_run_migrations(connectable)
 
+
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
 Above, using an asyncio database URL in ``alembic.ini`` one can run
 commands such as ``alembic upgrade`` from the command line.  Programmatically,
 the same ``env.py`` file can be invoked using asyncio as::


### PR DESCRIPTION
This part is missing from the example, and if a user started with the async template, then they would have an `asyncio.run()` call in here, which breaks the script.