### PR TITLE
Merge command passes string "config" instead of object to template

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -322,7 +322,7 @@ def merge(
 
     script = ScriptDirectory.from_config(config)
     template_args = {
-        "config": "config"  # Let templates use config for
+        "config": config  # Let templates use config for
         # e.g. multiple databases
     }
     return script.generate_revision(


### PR DESCRIPTION
`alembic merge` command passes string "config" instead of object to template, should match [RevisionContext](../blob/3b09a89d95f765399324dd53b4cb8504b0a7903b/alembic/autogenerate/api.py#L487)'s dict