### PR TITLE
add recursive_version_locations option for searching revision files

### DIFF
--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -973,7 +973,7 @@ class Script(revision.Revision):
                 # if a `sourceless` option is specified
                 continue
 
-            for filename in files:
+            for filename in sorted(files):
                 paths.append(os.path.join(root, filename))
 
             if scriptdir.sourceless:
@@ -992,6 +992,12 @@ class Script(revision.Revision):
 
             if not scriptdir.recursive_version_locations:
                 break
+
+            # the real script order is defined by revision,
+            # but it may be undefined if there are many files with a same
+            # `down_revision`, for a better user experience (ex. debugging),
+            # we use a deterministic order
+            dirs.sort()
 
         return paths
 

--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -967,7 +967,7 @@ class Script(revision.Revision):
     @classmethod
     def _list_py_dir(cls, scriptdir: ScriptDirectory, path: str) -> List[str]:
         paths = []
-        for root, dirs, files in os.walk(path):
+        for root, dirs, files in os.walk(path, topdown=True):
             if root.endswith("__pycache__"):
                 # a special case - we may include these files
                 # if a `sourceless` option is specified

--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -49,6 +49,10 @@ prepend_sys_path = .
 # version_path_separator = space
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# recursive_version_locations = false
+
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -51,6 +51,10 @@ prepend_sys_path = .
 # version_path_separator = space
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# recursive_version_locations = false
+
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -51,6 +51,10 @@ prepend_sys_path = .
 # version_path_separator = space
 version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# recursive_version_locations = false
+
 # the output encoding used when revision files
 # are written from script.py.mako
 # output_encoding = utf-8

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -177,6 +177,10 @@ The file generated with the "generic" configuration looks like::
     # version_path_separator = space
     version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
 
+    # set to 'true' to search source files recursively
+    # in each "version_locations" directory
+    # recursive_version_locations = false
+
     # the output encoding used when revision files
     # are written from script.py.mako
     # output_encoding = utf-8
@@ -331,6 +335,9 @@ This file contains the following features:
 * ``version_path_separator`` - a separator of ``version_locations`` paths.
   It should be defined if multiple ``version_locations`` is used.
   See :ref:`multiple_bases` for examples.
+
+* ``recursive_version_locations`` - when set to 'true', revision files
+  are searched recursively in each "version_locations" directory.
 
 * ``output_encoding`` - the encoding to use when Alembic writes the
   ``script.py.mako`` file into a new migration file.  Defaults to ``'utf-8'``.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
These changes implement recursive search for revision files. A new flag `recursive_version_locations` is added to config file `alembic.ini`.
Each `version_locations` path is separately searched recursively. Existing flag `sourceless` works as before this change.

As described in #760, the use case is to allow a user to manually reorganize his version location folder. It is possible to reorganize file structure at any time, without changing the configuration file. New revision files are created without any changes.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

Fixes: #760 
