### PR TITLE
Handle literal_column in ExcludeConstraint differently

### DIFF
--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -670,7 +670,11 @@ def _render_potential_column(
     value: Union[ColumnClause, Column], autogen_context: AutogenContext
 ) -> str:
     if isinstance(value, ColumnClause):
-        template = "%(prefix)scolumn(%(name)r)"
+        if value.is_literal:
+            # Support stuff like literal_column("int8range(from, to)") in ExcludeConstraint
+            template = "%(prefix)sliteral_column(%(name)r)"
+        else:
+            template = "%(prefix)scolumn(%(name)r)"
 
         return template % {
             "prefix": render._sqlalchemy_autogenerate_prefix(autogen_context),


### PR DESCRIPTION
render `literal_columns()` as `sa.literal_columns()` to allow for expressions in ExcludeConstraint.

Fixes: https://github.com/sqlalchemy/alembic/issues/1184

### Description

Before the change, a literal_column in an ExcludeConstraint ended up as a `column("...")`which in turn meant that the actual migration errored with

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn) column "id + 2" named in key does not exist

[SQL:
CREATE TABLE whatever2 (
        id BIGSERIAL NOT NULL,
        PRIMARY KEY (id),
        CONSTRAINT whatever_id_int8range_excl EXCLUDE USING gist (id WITH =, "id + 2" WITH =)
)
```

Note: the column name is interpreted as a quoted column named "id + 2".

After the fix, a literal_column is passed through, ending up in the correct SQL, which can be run on PG.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
