### PR TITLE
tooling: write_pyi.py: filter usage of raw-strings (rstrings)

### DIFF
--- a/tools/write_pyi.py
+++ b/tools/write_pyi.py
@@ -218,7 +218,8 @@ def _generate_stub_for_meth(
 
     fn_doc = base_method.__doc__ if base_method else fn.__doc__
     has_docs = gen_docs and fn_doc is not None
-    docs = 'r"""' + f"{fn_doc}" + '"""' if has_docs else ""
+    string_prefix = "r" if chr(92) in fn_doc else ""
+    docs = f'{string_prefix}"""' + f"{fn_doc}" + '"""' if has_docs else ""
 
     func_text = textwrap.dedent(
         f"""


### PR DESCRIPTION
### Description
While reading the diff between [`rel_1_10_2...rel_1_10_3`](https://github.com/sqlalchemy/alembic/compare/rel_1_10_2...rel_1_10_3), the introduction of r-strings drew my attention, and that resulted in some [discussion on the relevant commit](https://github.com/sqlalchemy/alembic/commit/bc0c305b7c2cc0401e250fcd6a725aacecdd6e33).

This changeset filters the production of r-strings during stub-generation to cases where docstrings contain escape (backslash, `\`) characters.

I'll admit that I didn't realize until today that these stubs are primarily for typechecking.  Since that's the case, I have doubts about whether the change is worthwhile (consistency and simplicity -- using r-strings for all docstrings in the stubs -- even if it's redundant, seems fine to me).

cc @CaselIT 

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
- [x] A short code fix
	- Relates to discussion at https://github.com/sqlalchemy/alembic/commit/bc0c305b7c2cc0401e250fcd6a725aacecdd6e33