### PR TITLE
ops.py: cleanup / consistency: remove redundant docstring newline markers

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -969,10 +969,10 @@ def execute(
             column('name', String)
         )
         op.execute(
-            account.update().\\
-                where(account.c.name==op.inline_literal('account 1')).\\
-                values({'name':op.inline_literal('account 2')})
-                )
+            account.update().
+            where(account.c.name==op.inline_literal('account 1')).
+            values({'name':op.inline_literal('account 2')})
+        )
 
     Above, we made use of the SQLAlchemy
     :func:`sqlalchemy.sql.expression.table` and
@@ -999,7 +999,8 @@ def execute(
         connection = op.get_bind()
 
         connection.execute(
-            account.update().where(account.c.name=='account 1').
+            account.update().
+            where(account.c.name=='account 1').
             values({"name": "account 2"})
         )
 

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -19,7 +19,6 @@ from sqlalchemy.sql.expression import TableClause
 from sqlalchemy.sql.expression import Update
 
 if TYPE_CHECKING:
-
     from sqlalchemy.engine import Connection
     from sqlalchemy.sql.elements import BinaryExpression
     from sqlalchemy.sql.elements import conv
@@ -965,13 +964,11 @@ def execute(
         from sqlalchemy import String
         from alembic import op
 
-        account = table('account',
-            column('name', String)
-        )
+        account = table("account", column("name", String))
         op.execute(
-            account.update().
-            where(account.c.name==op.inline_literal('account 1')).
-            values({'name':op.inline_literal('account 2')})
+            account.update()
+            .where(account.c.name == op.inline_literal("account 1"))
+            .values({"name": op.inline_literal("account 2")})
         )
 
     Above, we made use of the SQLAlchemy
@@ -996,12 +993,13 @@ def execute(
     also be used normally, use the "bind" available from the context::
 
         from alembic import op
+
         connection = op.get_bind()
 
         connection.execute(
-            account.update().
-            where(account.c.name=='account 1').
-            values({"name": "account 2"})
+            account.update()
+            .where(account.c.name == "account 1")
+            .values({"name": "account 2"})
         )
 
     Additionally, when passing the statement as a plain string, it is first

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -2339,13 +2339,11 @@ class ExecuteSQLOp(MigrateOperation):
             from sqlalchemy import String
             from alembic import op
 
-            account = table('account',
-                column('name', String)
-            )
+            account = table("account", column("name", String))
             op.execute(
-                account.update().
-                where(account.c.name==op.inline_literal('account 1')).
-                values({'name':op.inline_literal('account 2')})
+                account.update()
+                .where(account.c.name == op.inline_literal("account 1"))
+                .values({"name": op.inline_literal("account 2")})
             )
 
         Above, we made use of the SQLAlchemy
@@ -2370,12 +2368,13 @@ class ExecuteSQLOp(MigrateOperation):
         also be used normally, use the "bind" available from the context::
 
             from alembic import op
+
             connection = op.get_bind()
 
             connection.execute(
-                account.update().
-                where(account.c.name=='account 1').
-                values({"name": "account 2"})
+                account.update()
+                .where(account.c.name == "account 1")
+                .values({"name": "account 2"})
             )
 
         Additionally, when passing the statement as a plain string, it is first

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -2343,10 +2343,10 @@ class ExecuteSQLOp(MigrateOperation):
                 column('name', String)
             )
             op.execute(
-                account.update().\\
-                    where(account.c.name==op.inline_literal('account 1')).\\
-                    values({'name':op.inline_literal('account 2')})
-                    )
+                account.update().
+                where(account.c.name==op.inline_literal('account 1')).
+                values({'name':op.inline_literal('account 2')})
+            )
 
         Above, we made use of the SQLAlchemy
         :func:`sqlalchemy.sql.expression.table` and
@@ -2373,7 +2373,8 @@ class ExecuteSQLOp(MigrateOperation):
             connection = op.get_bind()
 
             connection.execute(
-                account.update().where(account.c.name=='account 1').
+                account.update().
+                where(account.c.name=='account 1').
                 values({"name": "account 2"})
             )
 


### PR DESCRIPTION
### Description
Potential (nitpicky) docstring cleanup discovered while preparing #1218.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix