### PR TITLE
Consistency: apply codestyle formatting to docstring code snippets

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 
 def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
-    '''Compare a database schema to that given in a
+    """Compare a database schema to that given in a
     :class:`~sqlalchemy.schema.MetaData` instance.
 
     The database connection is presented in the context
@@ -73,13 +73,13 @@ def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
         with engine.begin() as conn:
             conn.execute(
                 text(
-                    """
+                    '''
                         create table foo (
                             id integer not null primary key,
                             old_data varchar,
                             x integer
                         )
-                    """
+                    '''
                 )
             )
             conn.execute(text("create table bar (data varchar)"))
@@ -133,7 +133,7 @@ def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
         :func:`.produce_migrations` - produces a :class:`.MigrationScript`
         structure based on metadata comparison.
 
-    '''
+    """
 
     migration_script = produce_migrations(context, metadata)
     return migration_script.upgrade_ops.as_diffs()

--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 
 def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
-    """Compare a database schema to that given in a
+    '''Compare a database schema to that given in a
     :class:`~sqlalchemy.schema.MetaData` instance.
 
     The database connection is presented in the context
@@ -57,36 +57,42 @@ def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
 
         from alembic.migration import MigrationContext
         from alembic.autogenerate import compare_metadata
-        from sqlalchemy.schema import SchemaItem
-        from sqlalchemy.types import TypeEngine
-        from sqlalchemy import (create_engine, MetaData, Column,
-                Integer, String, Table, text)
+        from sqlalchemy import (
+            create_engine,
+            MetaData,
+            Column,
+            Integer,
+            String,
+            Table,
+            text,
+        )
         import pprint
 
         engine = create_engine("sqlite://")
 
         with engine.begin() as conn:
-            conn.execute(text('''
-                create table foo (
-                    id integer not null primary key,
-                    old_data varchar,
-                    x integer
-                )'''))
-
-            conn.execute(text('''
-                create table bar (
-                    data varchar
-                )'''))
+            conn.execute(
+                text(
+                    """
+                        create table foo (
+                            id integer not null primary key,
+                            old_data varchar,
+                            x integer
+                        )
+                    """
+                )
+            )
+            conn.execute(text("create table bar (data varchar)"))
 
         metadata = MetaData()
-        Table('foo', metadata,
-            Column('id', Integer, primary_key=True),
-            Column('data', Integer),
-            Column('x', Integer, nullable=False)
+        Table(
+            "foo",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("data", Integer),
+            Column("x", Integer, nullable=False),
         )
-        Table('bat', metadata,
-            Column('info', String)
-        )
+        Table("bat", metadata, Column("info", String))
 
         mc = MigrationContext.configure(engine.connect())
 
@@ -96,28 +102,26 @@ def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
     Output::
 
         [ ( 'add_table',
-            Table('bat', MetaData(bind=None),
-                Column('info', String(), table=<bat>), schema=None)),
+            Table('bat', MetaData(), Column('info', String(), table=<bat>), schema=None)),
           ( 'remove_table',
-            Table(u'bar', MetaData(bind=None),
-                Column(u'data', VARCHAR(), table=<bar>), schema=None)),
+            Table('bar', MetaData(), Column('data', VARCHAR(), table=<bar>), schema=None)),
           ( 'add_column',
             None,
             'foo',
             Column('data', Integer(), table=<foo>)),
-          ( 'remove_column',
-            None,
-            'foo',
-            Column(u'old_data', VARCHAR(), table=None)),
           [ ( 'modify_nullable',
               None,
               'foo',
-              u'x',
-              { 'existing_server_default': None,
+              'x',
+              { 'existing_comment': None,
+                'existing_server_default': False,
                 'existing_type': INTEGER()},
               True,
-              False)]]
-
+              False)],
+          ( 'remove_column',
+            None,
+            'foo',
+            Column('old_data', VARCHAR(), table=<foo>))]
 
     :param context: a :class:`.MigrationContext`
      instance.
@@ -129,7 +133,7 @@ def compare_metadata(context: MigrationContext, metadata: MetaData) -> Any:
         :func:`.produce_migrations` - produces a :class:`.MigrationScript`
         structure based on metadata comparison.
 
-    """
+    '''
 
     migration_script = produce_migrations(context, metadata)
     return migration_script.upgrade_ops.as_diffs()

--- a/alembic/autogenerate/rewriter.py
+++ b/alembic/autogenerate/rewriter.py
@@ -66,19 +66,17 @@ class Rewriter:
             writer1 = autogenerate.Rewriter()
             writer2 = autogenerate.Rewriter()
 
+
             @writer1.rewrites(ops.AddColumnOp)
             def add_column_nullable(context, revision, op):
                 op.column.nullable = True
                 return op
 
+
             @writer2.rewrites(ops.AddColumnOp)
             def add_column_idx(context, revision, op):
-                idx_op = ops.CreateIndexOp(
-                    'ixc', op.table_name, [op.column.name])
-                return [
-                    op,
-                    idx_op
-                ]
+                idx_op = ops.CreateIndexOp("ixc", op.table_name, [op.column.name])
+                return [op, idx_op]
 
             writer = writer1.chain(writer2)
 

--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -566,11 +566,9 @@ class CreateExcludeConstraintOp(ops.AddConstraintOp):
             op.create_exclude_constraint(
                 "user_excl",
                 "user",
-
-                ("period", '&&'),
-                ("group", '='),
-                where=("group != 'some group'")
-
+                ("period", "&&"),
+                ("group", "="),
+                where=("group != 'some group'"),
             )
 
         Note that the expressions work the same way as that of

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -51,8 +51,9 @@ def add_column(
         from alembic import op
         from sqlalchemy import Column, String
 
-        op.add_column('organization',
-            Column('name', String())
+        op.add_column(
+            "organization",
+            Column("name", String()),
         )
 
     The provided :class:`~sqlalchemy.schema.Column` object can also
@@ -64,8 +65,9 @@ def add_column(
         from alembic import op
         from sqlalchemy import Column, INTEGER, ForeignKey
 
-        op.add_column('organization',
-            Column('account_id', INTEGER, ForeignKey('accounts.id'))
+        op.add_column(
+            "organization",
+            Column("account_id", INTEGER, ForeignKey("accounts.id")),
         )
 
     Note that this statement uses the :class:`~sqlalchemy.schema.Column`
@@ -78,8 +80,9 @@ def add_column(
         from sqlalchemy import Column, TIMESTAMP, func
 
         # specify "DEFAULT NOW" along with the column add
-        op.add_column('account',
-            Column('timestamp', TIMESTAMP, server_default=func.now())
+        op.add_column(
+            "account",
+            Column("timestamp", TIMESTAMP, server_default=func.now()),
         )
 
     :param table_name: String name of the parent table.
@@ -241,8 +244,8 @@ def batch_alter_table(
     are omitted.  E.g.::
 
         with op.batch_alter_table("some_table") as batch_op:
-            batch_op.add_column(Column('foo', Integer))
-            batch_op.drop_column('bar')
+            batch_op.add_column(Column("foo", Integer))
+            batch_op.drop_column("bar")
 
     The operations within the context manager are invoked at once
     when the context is ended.   When run against SQLite, if the
@@ -321,16 +324,18 @@ def batch_alter_table(
      Specify the order of all columns::
 
         with op.batch_alter_table(
-                "some_table", recreate="always",
-                partial_reordering=[("c", "d", "a", "b")]
+            "some_table",
+            recreate="always",
+            partial_reordering=[("c", "d", "a", "b")],
         ) as batch_op:
             pass
 
      Ensure "d" appears before "c", and "b", appears before "a"::
 
         with op.batch_alter_table(
-                "some_table", recreate="always",
-                partial_reordering=[("d", "c"), ("b", "a")]
+            "some_table",
+            recreate="always",
+            partial_reordering=[("d", "c"), ("b", "a")],
         ) as batch_op:
             pass
 
@@ -370,37 +375,58 @@ def bulk_insert(
         from sqlalchemy import String, Integer, Date
 
         # Create an ad-hoc table to use for the insert statement.
-        accounts_table = table('account',
-            column('id', Integer),
-            column('name', String),
-            column('create_date', Date)
+        accounts_table = table(
+            "account",
+            column("id", Integer),
+            column("name", String),
+            column("create_date", Date),
         )
 
-        op.bulk_insert(accounts_table,
+        op.bulk_insert(
+            accounts_table,
             [
-                {'id':1, 'name':'John Smith',
-                        'create_date':date(2010, 10, 5)},
-                {'id':2, 'name':'Ed Williams',
-                        'create_date':date(2007, 5, 27)},
-                {'id':3, 'name':'Wendy Jones',
-                        'create_date':date(2008, 8, 15)},
-            ]
+                {
+                    "id": 1,
+                    "name": "John Smith",
+                    "create_date": date(2010, 10, 5),
+                },
+                {
+                    "id": 2,
+                    "name": "Ed Williams",
+                    "create_date": date(2007, 5, 27),
+                },
+                {
+                    "id": 3,
+                    "name": "Wendy Jones",
+                    "create_date": date(2008, 8, 15),
+                },
+            ],
         )
 
     When using --sql mode, some datatypes may not render inline
     automatically, such as dates and other special types.   When this
     issue is present, :meth:`.Operations.inline_literal` may be used::
 
-        op.bulk_insert(accounts_table,
+        op.bulk_insert(
+            accounts_table,
             [
-                {'id':1, 'name':'John Smith',
-                        'create_date':op.inline_literal("2010-10-05")},
-                {'id':2, 'name':'Ed Williams',
-                        'create_date':op.inline_literal("2007-05-27")},
-                {'id':3, 'name':'Wendy Jones',
-                        'create_date':op.inline_literal("2008-08-15")},
+                {
+                    "id": 1,
+                    "name": "John Smith",
+                    "create_date": op.inline_literal("2010-10-05"),
+                },
+                {
+                    "id": 2,
+                    "name": "Ed Williams",
+                    "create_date": op.inline_literal("2007-05-27"),
+                },
+                {
+                    "id": 3,
+                    "name": "Wendy Jones",
+                    "create_date": op.inline_literal("2008-08-15"),
+                },
             ],
-            multiinsert=False
+            multiinsert=False,
         )
 
     When using :meth:`.Operations.inline_literal` in conjunction with
@@ -446,7 +472,7 @@ def create_check_constraint(
         op.create_check_constraint(
             "ck_user_name_len",
             "user",
-            func.len(column('name')) > 5
+            func.len(column("name")) > 5,
         )
 
     CHECK constraints are usually against a SQL expression, so ad-hoc
@@ -492,11 +518,9 @@ def create_exclude_constraint(
         op.create_exclude_constraint(
             "user_excl",
             "user",
-
-            ("period", '&&'),
-            ("group", '='),
-            where=("group != 'some group'")
-
+            ("period", "&&"),
+            ("group", "="),
+            where=("group != 'some group'"),
         )
 
     Note that the expressions work the same way as that of
@@ -537,9 +561,14 @@ def create_foreign_key(
     e.g.::
 
         from alembic import op
+
         op.create_foreign_key(
-                    "fk_user_address", "address",
-                    "user", ["user_id"], ["id"])
+            "fk_user_address",
+            "address",
+            "user",
+            ["user_id"],
+            ["id"],
+        )
 
     This internally generates a :class:`~sqlalchemy.schema.Table` object
     containing the necessary columns, then generates a new
@@ -590,14 +619,16 @@ def create_index(
     e.g.::
 
         from alembic import op
-        op.create_index('ik_test', 't1', ['foo', 'bar'])
+
+        op.create_index("ik_test", "t1", ["foo", "bar"])
 
     Functional indexes can be produced by using the
     :func:`sqlalchemy.sql.expression.text` construct::
 
         from alembic import op
         from sqlalchemy import text
-        op.create_index('ik_test', 't1', [text('lower(foo)')])
+
+        op.create_index("ik_test", "t1", [text("lower(foo)")])
 
     :param index_name: name of the index.
     :param table_name: name of the owning table.
@@ -638,10 +669,12 @@ def create_primary_key(
     e.g.::
 
         from alembic import op
+
         op.create_primary_key(
-                    "pk_my_table", "my_table",
-                    ["id", "version"]
-                )
+            "pk_my_table",
+            "my_table",
+            ["id", "version"],
+        )
 
     This internally generates a :class:`~sqlalchemy.schema.Table` object
     containing the necessary columns, then generates a new
@@ -683,11 +716,11 @@ def create_table(
         from alembic import op
 
         op.create_table(
-            'account',
-            Column('id', INTEGER, primary_key=True),
-            Column('name', VARCHAR(50), nullable=False),
-            Column('description', NVARCHAR(200)),
-            Column('timestamp', TIMESTAMP, server_default=func.now())
+            "account",
+            Column("id", INTEGER, primary_key=True),
+            Column("name", VARCHAR(50), nullable=False),
+            Column("description", NVARCHAR(200)),
+            Column("timestamp", TIMESTAMP, server_default=func.now()),
         )
 
     Note that :meth:`.create_table` accepts
@@ -716,11 +749,11 @@ def create_table(
         from alembic import op
 
         account_table = op.create_table(
-            'account',
-            Column('id', INTEGER, primary_key=True),
-            Column('name', VARCHAR(50), nullable=False),
-            Column('description', NVARCHAR(200)),
-            Column('timestamp', TIMESTAMP, server_default=func.now())
+            "account",
+            Column("id", INTEGER, primary_key=True),
+            Column("name", VARCHAR(50), nullable=False),
+            Column("description", NVARCHAR(200)),
+            Column("timestamp", TIMESTAMP, server_default=func.now()),
         )
 
         op.bulk_insert(
@@ -728,7 +761,7 @@ def create_table(
             [
                 {"name": "A1", "description": "account 1"},
                 {"name": "A2", "description": "account 2"},
-            ]
+            ],
         )
 
     :param table_name: Name of the table
@@ -828,7 +861,7 @@ def drop_column(
 
     e.g.::
 
-        drop_column('organization', 'account_id')
+        drop_column("organization", "account_id")
 
     :param table_name: name of table
     :param column_name: name of column
@@ -1049,7 +1082,7 @@ def f(name: str) -> conv:
     If the :meth:`.Operations.f` is used on a constraint, the naming
     convention will not take effect::
 
-        op.add_column('t', 'x', Boolean(name=op.f('ck_bool_t_x')))
+        op.add_column("t", "x", Boolean(name=op.f("ck_bool_t_x")))
 
     Above, the CHECK constraint generated will have the name
     ``ck_bool_t_x`` regardless of whether or not a naming convention is
@@ -1061,7 +1094,7 @@ def f(name: str) -> conv:
     ``{"ck": "ck_bool_%(table_name)s_%(constraint_name)s"}``, then the
     output of the following:
 
-        op.add_column('t', 'x', Boolean(name='x'))
+        op.add_column("t", "x", Boolean(name="x"))
 
     will be::
 

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -259,8 +259,8 @@ class Operations(util.ModuleClsProxy):
         are omitted.  E.g.::
 
             with op.batch_alter_table("some_table") as batch_op:
-                batch_op.add_column(Column('foo', Integer))
-                batch_op.drop_column('bar')
+                batch_op.add_column(Column("foo", Integer))
+                batch_op.drop_column("bar")
 
         The operations within the context manager are invoked at once
         when the context is ended.   When run against SQLite, if the
@@ -339,16 +339,18 @@ class Operations(util.ModuleClsProxy):
          Specify the order of all columns::
 
             with op.batch_alter_table(
-                    "some_table", recreate="always",
-                    partial_reordering=[("c", "d", "a", "b")]
+                "some_table",
+                recreate="always",
+                partial_reordering=[("c", "d", "a", "b")],
             ) as batch_op:
                 pass
 
          Ensure "d" appears before "c", and "b", appears before "a"::
 
             with op.batch_alter_table(
-                    "some_table", recreate="always",
-                    partial_reordering=[("d", "c"), ("b", "a")]
+                "some_table",
+                recreate="always",
+                partial_reordering=[("d", "c"), ("b", "a")],
             ) as batch_op:
                 pass
 
@@ -414,7 +416,7 @@ class Operations(util.ModuleClsProxy):
         If the :meth:`.Operations.f` is used on a constraint, the naming
         convention will not take effect::
 
-            op.add_column('t', 'x', Boolean(name=op.f('ck_bool_t_x')))
+            op.add_column("t", "x", Boolean(name=op.f("ck_bool_t_x")))
 
         Above, the CHECK constraint generated will have the name
         ``ck_bool_t_x`` regardless of whether or not a naming convention is
@@ -426,7 +428,7 @@ class Operations(util.ModuleClsProxy):
         ``{"ck": "ck_bool_%(table_name)s_%(constraint_name)s"}``, then the
         output of the following:
 
-            op.add_column('t', 'x', Boolean(name='x'))
+            op.add_column("t", "x", Boolean(name="x"))
 
         will be::
 

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -307,10 +307,12 @@ class CreatePrimaryKeyOp(AddConstraintOp):
         e.g.::
 
             from alembic import op
+
             op.create_primary_key(
-                        "pk_my_table", "my_table",
-                        ["id", "version"]
-                    )
+                "pk_my_table",
+                "my_table",
+                ["id", "version"],
+            )
 
         This internally generates a :class:`~sqlalchemy.schema.Table` object
         containing the necessary columns, then generates a new
@@ -608,9 +610,14 @@ class CreateForeignKeyOp(AddConstraintOp):
         e.g.::
 
             from alembic import op
+
             op.create_foreign_key(
-                        "fk_user_address", "address",
-                        "user", ["user_id"], ["id"])
+                "fk_user_address",
+                "address",
+                "user",
+                ["user_id"],
+                ["id"],
+            )
 
         This internally generates a :class:`~sqlalchemy.schema.Table` object
         containing the necessary columns, then generates a new
@@ -690,8 +697,11 @@ class CreateForeignKeyOp(AddConstraintOp):
 
             with batch_alter_table("address") as batch_op:
                 batch_op.create_foreign_key(
-                            "fk_user_address",
-                            "user", ["user_id"], ["id"])
+                    "fk_user_address",
+                    "user",
+                    ["user_id"],
+                    ["id"],
+                )
 
         .. seealso::
 
@@ -790,7 +800,7 @@ class CreateCheckConstraintOp(AddConstraintOp):
             op.create_check_constraint(
                 "ck_user_name_len",
                 "user",
-                func.len(column('name')) > 5
+                func.len(column("name")) > 5,
             )
 
         CHECK constraints are usually against a SQL expression, so ad-hoc
@@ -922,14 +932,16 @@ class CreateIndexOp(MigrateOperation):
         e.g.::
 
             from alembic import op
-            op.create_index('ik_test', 't1', ['foo', 'bar'])
+
+            op.create_index("ik_test", "t1", ["foo", "bar"])
 
         Functional indexes can be produced by using the
         :func:`sqlalchemy.sql.expression.text` construct::
 
             from alembic import op
             from sqlalchemy import text
-            op.create_index('ik_test', 't1', [text('lower(foo)')])
+
+            op.create_index("ik_test", "t1", [text("lower(foo)")])
 
         :param index_name: name of the index.
         :param table_name: name of the owning table.
@@ -1186,11 +1198,11 @@ class CreateTableOp(MigrateOperation):
             from alembic import op
 
             op.create_table(
-                'account',
-                Column('id', INTEGER, primary_key=True),
-                Column('name', VARCHAR(50), nullable=False),
-                Column('description', NVARCHAR(200)),
-                Column('timestamp', TIMESTAMP, server_default=func.now())
+                "account",
+                Column("id", INTEGER, primary_key=True),
+                Column("name", VARCHAR(50), nullable=False),
+                Column("description", NVARCHAR(200)),
+                Column("timestamp", TIMESTAMP, server_default=func.now()),
             )
 
         Note that :meth:`.create_table` accepts
@@ -1219,11 +1231,11 @@ class CreateTableOp(MigrateOperation):
             from alembic import op
 
             account_table = op.create_table(
-                'account',
-                Column('id', INTEGER, primary_key=True),
-                Column('name', VARCHAR(50), nullable=False),
-                Column('description', NVARCHAR(200)),
-                Column('timestamp', TIMESTAMP, server_default=func.now())
+                "account",
+                Column("id", INTEGER, primary_key=True),
+                Column("name", VARCHAR(50), nullable=False),
+                Column("description", NVARCHAR(200)),
+                Column("timestamp", TIMESTAMP, server_default=func.now()),
             )
 
             op.bulk_insert(
@@ -1231,7 +1243,7 @@ class CreateTableOp(MigrateOperation):
                 [
                     {"name": "A1", "description": "account 1"},
                     {"name": "A2", "description": "account 2"},
-                ]
+                ],
             )
 
         :param table_name: Name of the table
@@ -1999,8 +2011,9 @@ class AddColumnOp(AlterTableOp):
             from alembic import op
             from sqlalchemy import Column, String
 
-            op.add_column('organization',
-                Column('name', String())
+            op.add_column(
+                "organization",
+                Column("name", String()),
             )
 
         The provided :class:`~sqlalchemy.schema.Column` object can also
@@ -2012,8 +2025,9 @@ class AddColumnOp(AlterTableOp):
             from alembic import op
             from sqlalchemy import Column, INTEGER, ForeignKey
 
-            op.add_column('organization',
-                Column('account_id', INTEGER, ForeignKey('accounts.id'))
+            op.add_column(
+                "organization",
+                Column("account_id", INTEGER, ForeignKey("accounts.id")),
             )
 
         Note that this statement uses the :class:`~sqlalchemy.schema.Column`
@@ -2026,8 +2040,9 @@ class AddColumnOp(AlterTableOp):
             from sqlalchemy import Column, TIMESTAMP, func
 
             # specify "DEFAULT NOW" along with the column add
-            op.add_column('account',
-                Column('timestamp', TIMESTAMP, server_default=func.now())
+            op.add_column(
+                "account",
+                Column("timestamp", TIMESTAMP, server_default=func.now()),
             )
 
         :param table_name: String name of the parent table.
@@ -2150,7 +2165,7 @@ class DropColumnOp(AlterTableOp):
 
         e.g.::
 
-            drop_column('organization', 'account_id')
+            drop_column("organization", "account_id")
 
         :param table_name: name of table
         :param column_name: name of column
@@ -2245,37 +2260,58 @@ class BulkInsertOp(MigrateOperation):
             from sqlalchemy import String, Integer, Date
 
             # Create an ad-hoc table to use for the insert statement.
-            accounts_table = table('account',
-                column('id', Integer),
-                column('name', String),
-                column('create_date', Date)
+            accounts_table = table(
+                "account",
+                column("id", Integer),
+                column("name", String),
+                column("create_date", Date),
             )
 
-            op.bulk_insert(accounts_table,
+            op.bulk_insert(
+                accounts_table,
                 [
-                    {'id':1, 'name':'John Smith',
-                            'create_date':date(2010, 10, 5)},
-                    {'id':2, 'name':'Ed Williams',
-                            'create_date':date(2007, 5, 27)},
-                    {'id':3, 'name':'Wendy Jones',
-                            'create_date':date(2008, 8, 15)},
-                ]
+                    {
+                        "id": 1,
+                        "name": "John Smith",
+                        "create_date": date(2010, 10, 5),
+                    },
+                    {
+                        "id": 2,
+                        "name": "Ed Williams",
+                        "create_date": date(2007, 5, 27),
+                    },
+                    {
+                        "id": 3,
+                        "name": "Wendy Jones",
+                        "create_date": date(2008, 8, 15),
+                    },
+                ],
             )
 
         When using --sql mode, some datatypes may not render inline
         automatically, such as dates and other special types.   When this
         issue is present, :meth:`.Operations.inline_literal` may be used::
 
-            op.bulk_insert(accounts_table,
+            op.bulk_insert(
+                accounts_table,
                 [
-                    {'id':1, 'name':'John Smith',
-                            'create_date':op.inline_literal("2010-10-05")},
-                    {'id':2, 'name':'Ed Williams',
-                            'create_date':op.inline_literal("2007-05-27")},
-                    {'id':3, 'name':'Wendy Jones',
-                            'create_date':op.inline_literal("2008-08-15")},
+                    {
+                        "id": 1,
+                        "name": "John Smith",
+                        "create_date": op.inline_literal("2010-10-05"),
+                    },
+                    {
+                        "id": 2,
+                        "name": "Ed Williams",
+                        "create_date": op.inline_literal("2007-05-27"),
+                    },
+                    {
+                        "id": 3,
+                        "name": "Wendy Jones",
+                        "create_date": op.inline_literal("2008-08-15"),
+                    },
                 ],
-                multiinsert=False
+                multiinsert=False,
             )
 
         When using :meth:`.Operations.inline_literal` in conjunction with

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -39,7 +39,7 @@ ProcessRevisionDirectiveFn = Callable[
 
 class EnvironmentContext(util.ModuleClsProxy):
 
-    '''A configurational facade made available in an ``env.py`` script.
+    """A configurational facade made available in an ``env.py`` script.
 
     The :class:`.EnvironmentContext` acts as a *facade* to the more
     nuts-and-bolts objects of :class:`.MigrationContext` as well as certain
@@ -67,10 +67,10 @@ class EnvironmentContext(util.ModuleClsProxy):
 
 
         def my_function(rev, context):
-            """do something with revision "rev", which
+            '''do something with revision "rev", which
             will be the current database revision,
             and "context", which is the MigrationContext
-            that the env.py will create"""
+            that the env.py will create'''
 
 
         with EnvironmentContext(
@@ -100,7 +100,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         is *only* needed when you need to actually invoke the
         ``env.py`` module present in the migration environment.
 
-    '''
+    """
 
     _migration_context: Optional[MigrationContext] = None
 

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -39,7 +39,7 @@ ProcessRevisionDirectiveFn = Callable[
 
 class EnvironmentContext(util.ModuleClsProxy):
 
-    """A configurational facade made available in an ``env.py`` script.
+    '''A configurational facade made available in an ``env.py`` script.
 
     The :class:`.EnvironmentContext` acts as a *facade* to the more
     nuts-and-bolts objects of :class:`.MigrationContext` as well as certain
@@ -65,20 +65,22 @@ class EnvironmentContext(util.ModuleClsProxy):
         config.set_main_option("script_location", "myapp:migrations")
         script = ScriptDirectory.from_config(config)
 
+
         def my_function(rev, context):
-            '''do something with revision "rev", which
+            """do something with revision "rev", which
             will be the current database revision,
             and "context", which is the MigrationContext
-            that the env.py will create'''
+            that the env.py will create"""
+
 
         with EnvironmentContext(
             config,
             script,
-            fn = my_function,
-            as_sql = False,
-            starting_rev = 'base',
-            destination_rev = 'head',
-            tag = "sometag"
+            fn=my_function,
+            as_sql=False,
+            starting_rev="base",
+            destination_rev="head",
+            tag="sometag",
         ):
             script.run_env()
 
@@ -98,7 +100,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         is *only* needed when you need to actually invoke the
         ``env.py`` module present in the migration environment.
 
-    """
+    '''
 
     _migration_context: Optional[MigrationContext] = None
 

--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -97,6 +97,7 @@ class MigrationContext:
 
         # from within env.py script
         from alembic import context
+
         migration_context = context.get_context()
 
     For usage outside of an ``env.py`` script, such as for
@@ -122,6 +123,7 @@ class MigrationContext:
 
         # in any application, outside of the normal Alembic environment
         from alembic.operations import Operations
+
         op = Operations(context)
         op.alter_column("mytable", "somecolumn", nullable=True)
 


### PR DESCRIPTION
### Description
This is a pedantic/consistency follow-up from #1219: that change applied some `black` formatting to two code snippets, and this change applies that formatting to the remaining snippets in the codebase.

For each snippet, I extracted the code and applied formatting using `black` v23.1.0, then placed the results back into the source.

In one case there was an associated 'output' block, and in that case I re-ran the snippet code to update the results of that output too (this included a [change-in-output](https://github.com/sqlalchemy/alembic/compare/main...openculinary:alembic:docstrings/snippet-format-consistency?expand=1#diff-bf4756660cdb31ee8566a2cff72526671356c38a725195723ce0e65e6c11e6cfR124) thanks to a [bugfix since the snippet was written](https://github.com/sqlalchemy/alembic/commit/bc6971aa4abdafb7e1a1123c26a373cc25a34ca9), by the looks of it).

### Checklist

This pull request is:

- [x] A documentation / typographical error fix