### PR TITLE
Followup / fixup: apply 'black' code formatting to a couple of missed docstrings

### DIFF
--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -1214,9 +1214,10 @@ class CreateTableOp(MigrateOperation):
             from sqlalchemy import Column, TIMESTAMP, func
 
             # specify "DEFAULT NOW" along with the "timestamp" column
-            op.create_table('account',
-                Column('id', INTEGER, primary_key=True),
-                Column('timestamp', TIMESTAMP, server_default=func.now())
+            op.create_table(
+                "account",
+                Column("id", INTEGER, primary_key=True),
+                Column("timestamp", TIMESTAMP, server_default=func.now()),
             )
 
         The function also returns a newly created

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -308,9 +308,7 @@ class CreatePrimaryKeyOp(AddConstraintOp):
 
             from alembic import op
 
-            op.create_primary_key(
-                "pk_my_table", "my_table", ["id", "version"]
-            )
+            op.create_primary_key("pk_my_table", "my_table", ["id", "version"])
 
         This internally generates a :class:`~sqlalchemy.schema.Table` object
         containing the necessary columns, then generates a new

--- a/docs/build/changelog.rst
+++ b/docs/build/changelog.rst
@@ -7,6 +7,12 @@ Changelog
     :version: 1.10.5
     :include_notes_from: unreleased
 
+    .. change::
+        :tags: misc
+        :tickets: 1220
+
+        Update code snippets within docstrings to use ``black`` code formatting.
+
 .. changelog::
     :version: 1.10.4
     :released: April 24, 2023


### PR DESCRIPTION
### Description
Follow-up / completion of #1220.  That change updated a number of docstrings within the codebase to use standardised `black` code formatting, but a couple of locations had been missed.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed