### PR TITLE
alembic/ddl/sqlite.py: enhance the judgment condition to fix the problem of AttributeError: 'NoneType' object has no attribute 'persisted' in the requires_recreate_in_batch function.

### DIFF
--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -60,7 +60,7 @@ class SQLiteImpl(DefaultImpl):
                     return True
                 elif (
                     isinstance(col.server_default, util.sqla_compat.Computed)
-                    and col.server_default.persisted
+                    and col.server_default and col.server_default.persisted
                 ):
                     return True
             elif op[0] not in ("create_index", "drop_index"):


### PR DESCRIPTION
Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>