### PR TITLE
Fixed CLI output when running post_write hooks

### DIFF
--- a/alembic/script/write_hooks.py
+++ b/alembic/script/write_hooks.py
@@ -85,7 +85,9 @@ def _run_hooks(path: str, hook_config: Mapping[str, str]) -> None:
                 "Key %s.type is required for post write hook %r" % (name, name)
             ) from ke
         else:
-            with util.status("Running post write hook {name!r}", newline=True):
+            with util.status(
+                "Running post write hook %r" % name, newline=True
+            ):
                 _invoke(type_, path, opts)
 
 

--- a/alembic/script/write_hooks.py
+++ b/alembic/script/write_hooks.py
@@ -56,7 +56,7 @@ def _invoke(
         hook = _registry[name]
     except KeyError as ke:
         raise util.CommandError(
-            "No formatter with name '%s' registered" % name
+            f"No formatter with name '{name}' registered"
         ) from ke
     else:
         return hook(revision, options)
@@ -82,11 +82,11 @@ def _run_hooks(path: str, hook_config: Mapping[str, str]) -> None:
             type_ = opts["type"]
         except KeyError as ke:
             raise util.CommandError(
-                "Key %s.type is required for post write hook %r" % (name, name)
+                f"Key {name}.type is required for post write hook {name!r}"
             ) from ke
         else:
             with util.status(
-                "Running post write hook %r" % name, newline=True
+                f"Running post write hook {name!r}", newline=True
             ):
                 _invoke(type_, path, opts)
 
@@ -120,8 +120,8 @@ def console_scripts(
         entrypoint_name = options["entrypoint"]
     except KeyError as ke:
         raise util.CommandError(
-            "Key %s.entrypoint is required for post write hook %r"
-            % (options["_hook_name"], options["_hook_name"])
+            f"Key {options['_hook_name']}.entrypoint is required for post "
+            f"write hook {options['_hook_name']!r}"
         ) from ke
     for entry in compat.importlib_metadata_get("console_scripts"):
         if entry.name == entrypoint_name:
@@ -143,7 +143,7 @@ def console_scripts(
         [
             sys.executable,
             "-c",
-            "import %s; %s.%s()" % (impl.module, impl.module, impl.attr),
+            f"import {impl.module}; {impl.module}.{impl.attr}()",
         ]
         + cmdline_options_list,
         cwd=cwd,


### PR DESCRIPTION
Fixes: #1261 

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Just fixed badly written Python string interpolation. Used the `%` operator just like the lines above.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
