### PR TITLE
Specify `"locale"` encoding when reading configuration file

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -201,9 +201,7 @@ class Config:
         self.config_args["here"] = here
         file_config = ConfigParser(self.config_args)
         if self.config_file_name:
-            # python >=3.10 supports "locale" instead of locale.getencoding()
-            # https://docs.python.org/3/whatsnew/3.10.html#optional-encodingwarning-and-encoding-locale-option
-            file_config.read([self.config_file_name], getencoding())
+            compat.read_config_parser(file_config, [self.config_file_name])
         else:
             file_config.add_section(self.config_ini_section)
         return file_config

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -200,7 +200,7 @@ class Config:
         self.config_args["here"] = here
         file_config = ConfigParser(self.config_args)
         if self.config_file_name:
-            file_config.read([self.config_file_name], "utf-8")
+            file_config.read([self.config_file_name], "locale")
         else:
             file_config.add_section(self.config_ini_section)
         return file_config

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -6,6 +6,7 @@ from configparser import ConfigParser
 import inspect
 import os
 import sys
+from locale import getencoding
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -200,7 +201,9 @@ class Config:
         self.config_args["here"] = here
         file_config = ConfigParser(self.config_args)
         if self.config_file_name:
-            file_config.read([self.config_file_name], "locale")
+            # python >=3.10 supports "locale" instead of locale.getencoding()
+            # https://docs.python.org/3/whatsnew/3.10.html#optional-encodingwarning-and-encoding-locale-option
+            file_config.read([self.config_file_name], getencoding())
         else:
             file_config.add_section(self.config_ini_section)
         return file_config

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -6,7 +6,6 @@ from configparser import ConfigParser
 import inspect
 import os
 import sys
-from locale import getencoding
 from typing import Any
 from typing import cast
 from typing import Dict

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -200,7 +200,7 @@ class Config:
         self.config_args["here"] = here
         file_config = ConfigParser(self.config_args)
         if self.config_file_name:
-            file_config.read([self.config_file_name])
+            file_config.read([self.config_file_name], "utf-8")
         else:
             file_config.add_section(self.config_ini_section)
         return file_config

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import io
 import os
 import sys
-import typing
 from configparser import ConfigParser
+import typing
 from typing import Sequence
 from typing import Union
 

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -4,7 +4,9 @@ import io
 import os
 import sys
 import typing
+from configparser import ConfigParser
 from typing import Sequence
+from typing import Union
 
 from sqlalchemy.util import inspect_getfullargspec  # noqa
 from sqlalchemy.util.compat import inspect_formatargspec  # noqa
@@ -60,7 +62,11 @@ def formatannotation_fwdref(annotation, base_module=None):
         return repr(annotation).replace("~", "")
     return repr(annotation).replace("~", "")
 
-def read_config_parser(file_config, file_argument):
+
+def read_config_parser(
+    file_config: ConfigParser,
+    file_argument: Sequence[Union[str, os.PathLike[str]]],
+) -> list[str]:
     if py310:
         return file_config.read(file_argument, encoding="locale")
     else:

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -12,6 +12,7 @@ from sqlalchemy.util.compat import inspect_formatargspec  # noqa
 is_posix = os.name == "posix"
 
 py311 = sys.version_info >= (3, 11)
+py310 = sys.version_info >= (3, 10)
 py39 = sys.version_info >= (3, 9)
 py38 = sys.version_info >= (3, 8)
 
@@ -58,3 +59,9 @@ def formatannotation_fwdref(annotation, base_module=None):
     elif isinstance(annotation, typing.TypeVar):
         return repr(annotation).replace("~", "")
     return repr(annotation).replace("~", "")
+
+def read_config_parser(file_config, file_argument):
+    if py310:
+        return file_config.read(file_argument, encoding="locale")
+    else:
+        return file_config.read(file_argument)


### PR DESCRIPTION
### Description
This merge request explicitly sets the encoding of the configuration file being read to "utf-8" as recommended by https://docs.python.org/3/library/io.html#opt-in-encodingwarning

Fixes: https://github.com/sqlalchemy/alembic/issues/1273

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
