### PR TITLE
Implement new `exec` write-hook runner that will execute arbitrary binaries

### DIFF
--- a/alembic/script/write_hooks.py
+++ b/alembic/script/write_hooks.py
@@ -152,9 +152,7 @@ def console_scripts(
 
 
 @register("exec")
-def exec(
-    path: str, options: dict, ignore_output: bool = False
-) -> None:
+def exec_(path: str, options: dict, ignore_output: bool = False) -> None:
     try:
         executable = options["executable"]
     except KeyError as ke:

--- a/alembic/script/write_hooks.py
+++ b/alembic/script/write_hooks.py
@@ -149,3 +149,32 @@ def console_scripts(
         cwd=cwd,
         **kw,
     )
+
+
+@register("exec")
+def exec(
+    path: str, options: dict, ignore_output: bool = False
+) -> None:
+    try:
+        executable = options["executable"]
+    except KeyError as ke:
+        raise util.CommandError(
+            f"Key {options['_hook_name']}.executable is required for post "
+            f"write hook {options['_hook_name']!r}"
+        ) from ke
+    cwd: Optional[str] = options.get("cwd", None)
+    cmdline_options_str = options.get("options", "")
+    cmdline_options_list = _parse_cmdline_options(cmdline_options_str, path)
+
+    kw: Dict[str, Any] = {}
+    if ignore_output:
+        kw["stdout"] = kw["stderr"] = subprocess.DEVNULL
+
+    subprocess.run(
+        [
+            executable,
+            *cmdline_options_list,
+        ],
+        cwd=cwd,
+        **kw,
+    )

--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -72,7 +72,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# format using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
 # ruff.executable = %(here)s/.venv/bin/ruff

--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -72,6 +72,12 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
+# format using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = .venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -75,7 +75,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # format using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = .venv/bin/ruff
+# ruff.executable = %(here)s/.venv/bin/ruff
 # ruff.options = --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -74,7 +74,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# format using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
 # ruff.executable = %(here)s/.venv/bin/ruff

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -74,6 +74,12 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
+# format using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = .venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -77,7 +77,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # format using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = .venv/bin/ruff
+# ruff.executable = %(here)s/.venv/bin/ruff
 # ruff.options = --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -79,6 +79,12 @@ sqlalchemy.url = driver://user:pass@localhost/dbname2
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
+# format using "ruff" - use the exec runner, execute a binary
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = .venv/bin/ruff
+# ruff.options = --fix REVISION_SCRIPT_FILENAME
+
 # Logging configuration
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -79,7 +79,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname2
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# format using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
 # ruff.executable = %(here)s/.venv/bin/ruff

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -82,7 +82,7 @@ sqlalchemy.url = driver://user:pass@localhost/dbname2
 # format using "ruff" - use the exec runner, execute a binary
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = .venv/bin/ruff
+# ruff.executable = %(here)s/.venv/bin/ruff
 # ruff.options = --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration

--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -730,8 +730,8 @@ Basic Formatter Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``alembic.ini`` samples now include commented-out configuration
-illustrating how to configure code-formatting tools to run against the newly
-generated file path.    Example::
+illustrating how to configure code-formatting tools, or other tools like linters
+to run against the newly generated file path.    Example::
 
   [post_write_hooks]
 
@@ -753,6 +753,8 @@ configuration for the ``"black"`` post write hook, which includes:
   ``subprocess.run()`` to execute an arbitrary binary.  For a custom-written
   hook function, this configuration variable would refer to the name under
   which the custom hook was registered; see the next section for an example.
+
+.. versionadded:: 1.12 added new ``exec`` runner
 
 The following configuration option is specific to the ``"console_scripts"``
 hook runner:
@@ -787,7 +789,7 @@ The following options are supported by both ``"console_scripts"`` and ``"exec"``
         autopep8.entrypoint = autopep8
         autopep8.options = --in-place REVISION_SCRIPT_FILENAME
 
-* ``cwd`` - optional working directory from which the formatting tool is run.
+* ``cwd`` - optional working directory from which the code processing tool is run.
 
 When running ``alembic revision -m "rev1"``, we will now see the ``black``
 tool's output as well::

--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -747,19 +747,28 @@ Above, we configure ``hooks`` to be a single post write hook labeled
 configuration for the ``"black"`` post write hook, which includes:
 
 * ``type`` - this is the type of hook we are running.  Alembic includes
-  a hook runner called ``"console_scripts"``, which is specifically a
+  two hook runners: ``"console_scripts"``, which is specifically a
   Python function that uses ``subprocess.run()`` to invoke a separate
-  Python script against the revision file.  For a custom-written hook
-  function, this configuration variable would refer to the name under
+  Python script against the revision file; and ``"exec"``, which uses
+  ``subprocess.run()`` to execute an arbitrary binary.  For a custom-written
+  hook function, this configuration variable would refer to the name under
   which the custom hook was registered; see the next section for an example.
 
-The following configuration options are specific to the ``"console_scripts"``
+The following configuration option is specific to the ``"console_scripts"``
 hook runner:
 
 * ``entrypoint`` - the name of the `setuptools entrypoint <https://setuptools.readthedocs.io/en/latest/pkg_resources.html#entry-points>`_
   that is used to define the console script.   Within the scope of standard
   Python console scripts, this name will match the name of the shell command
   that is usually run for the code formatting tool, in this case ``black``.
+
+The following configuration option is specific to the ``"exec"`` hook runner:
+
+* ``executable`` - the name of the executable to invoke.  Can be either a
+bare executable name which will be searched in ``$PATH``, or a full pathname
+to avoid potential issues with path interception.
+
+The following options are supported by both ``"console_scripts"`` and ``"exec"``:
 
 * ``options`` - a line of command-line options that will be passed to
   the code formatting tool.  In this case, we want to run the command
@@ -778,7 +787,7 @@ hook runner:
         autopep8.entrypoint = autopep8
         autopep8.options = --in-place REVISION_SCRIPT_FILENAME
 
-* ``cwd`` - optional working directory from which the console script is run.
+* ``cwd`` - optional working directory from which the formatting tool is run.
 
 When running ``alembic revision -m "rev1"``, we will now see the ``black``
 tool's output as well::

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -200,6 +200,12 @@ The file generated with the "generic" configuration looks like::
     # black.entrypoint = black
     # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
+    # format using "ruff" - use the exec runner, execute a binary
+    # hooks = ruff
+    # ruff.type = exec
+    # ruff.executable = .venv/bin/ruff
+    # ruff.options = --fix REVISION_SCRIPT_FILENAME
+
     # Logging configuration
     [loggers]
     keys = root,sqlalchemy,alembic

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -200,7 +200,7 @@ The file generated with the "generic" configuration looks like::
     # black.entrypoint = black
     # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-    # format using "ruff" - use the exec runner, execute a binary
+    # lint with attempts to fix using "ruff" - use the exec runner, execute a binary
     # hooks = ruff
     # ruff.type = exec
     # ruff.executable = %(here)s/.venv/bin/ruff

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -203,7 +203,7 @@ The file generated with the "generic" configuration looks like::
     # format using "ruff" - use the exec runner, execute a binary
     # hooks = ruff
     # ruff.type = exec
-    # ruff.executable = .venv/bin/ruff
+    # ruff.executable = %(here)s/.venv/bin/ruff
     # ruff.options = --fix REVISION_SCRIPT_FILENAME
 
     # Logging configuration

--- a/tests/test_post_write.py
+++ b/tests/test_post_write.py
@@ -318,7 +318,7 @@ ruff.options = --fix
 [post_write_hooks]
 hooks = ruff
 ruff.type = exec
-ruff.executable = ./.venv/bin/ruff
+ruff.executable = %(here)s/.venv/bin/ruff
 ruff.options = --fix
         """
 
@@ -327,7 +327,7 @@ ruff.options = --fix
 
         self._run_ruff_with_config(
             input_config, expected_additional_arguments_fn,
-            executable="./.venv/bin/ruff",
+            executable=os.path.abspath(_get_staging_directory()) + "/.venv/bin/ruff",
         )
 
     @combinations(True, False)

--- a/tests/test_post_write.py
+++ b/tests/test_post_write.py
@@ -274,7 +274,8 @@ black.cwd = /path/to/cwd
         )
 
     def _run_ruff_with_config(
-        self, input_config, expected_additional_arguments_fn, cwd=None
+        self, input_config, expected_additional_arguments_fn, executable="ruff",
+        cwd=None,
     ):
         self.cfg = _no_sql_testing_config(directives=input_config)
 
@@ -288,7 +289,7 @@ black.cwd = /path/to/cwd
             [
                 mock.call.run(
                     [
-                        "ruff",
+                        executable,
                     ]
                     + expected_additional_arguments_fn(rev.path),
                     cwd=cwd,
@@ -296,7 +297,7 @@ black.cwd = /path/to/cwd
             ],
         )
 
-    def test_exec(self):
+    def test_exec_with_path_search(self):
         input_config = """
 [post_write_hooks]
 hooks = ruff
@@ -310,6 +311,23 @@ ruff.options = --fix
 
         self._run_ruff_with_config(
             input_config, expected_additional_arguments_fn
+        )
+
+    def test_exec_with_full_pathname(self):
+        input_config = """
+[post_write_hooks]
+hooks = ruff
+ruff.type = exec
+ruff.executable = ./.venv/bin/ruff
+ruff.options = --fix
+        """
+
+        def expected_additional_arguments_fn(rev_path):
+            return [rev_path, "--fix"]
+
+        self._run_ruff_with_config(
+            input_config, expected_additional_arguments_fn,
+            executable="./.venv/bin/ruff",
         )
 
     @combinations(True, False)

--- a/tests/test_post_write.py
+++ b/tests/test_post_write.py
@@ -260,9 +260,7 @@ black.cwd = /path/to/cwd
     def test_exec_executable_missing(self):
         self.cfg = _no_sql_testing_config(
             directives=(
-                "\n[post_write_hooks]\n"
-                "hooks=ruff\n"
-                "ruff.type=exec\n"
+                "\n[post_write_hooks]\n" "hooks=ruff\n" "ruff.type=exec\n"
             )
         )
         assert_raises_message(
@@ -274,7 +272,10 @@ black.cwd = /path/to/cwd
         )
 
     def _run_ruff_with_config(
-        self, input_config, expected_additional_arguments_fn, executable="ruff",
+        self,
+        input_config,
+        expected_additional_arguments_fn,
+        executable="ruff",
         cwd=None,
     ):
         self.cfg = _no_sql_testing_config(directives=input_config)
@@ -326,8 +327,10 @@ ruff.options = --fix
             return [rev_path, "--fix"]
 
         self._run_ruff_with_config(
-            input_config, expected_additional_arguments_fn,
-            executable=os.path.abspath(_get_staging_directory()) + "/.venv/bin/ruff",
+            input_config,
+            expected_additional_arguments_fn,
+            executable=os.path.abspath(_get_staging_directory())
+            + "/.venv/bin/ruff",
         )
 
     @combinations(True, False)


### PR DESCRIPTION
Fixes #1275 

### Description
Implements new `exec` post-write hook runner that will execute arbitrary binaries, not just Python modules' entrypoints.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
