### PR TITLE
Accept insert and delete expressions in `op.execute`

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -155,7 +155,7 @@ class DefaultImpl(metaclass=ImplMeta):
 
     def _exec(
         self,
-        construct: Union[ClauseElement, str],
+        construct: Union[Executable, str],
         execution_options: Optional[dict[str, Any]] = None,
         multiparams: Sequence[dict] = (),
         params: Dict[str, Any] = util.immutabledict(),

--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Dialect
     from sqlalchemy.engine.cursor import CursorResult
     from sqlalchemy.engine.reflection import Inspector
+    from sqlalchemy.sql.base import Executable
     from sqlalchemy.sql.elements import ClauseElement
     from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.elements import quoted_name
@@ -196,7 +197,7 @@ class DefaultImpl(metaclass=ImplMeta):
 
     def execute(
         self,
-        sql: Union[ClauseElement, str],
+        sql: Union[Executable, str],
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:
         self._exec(sql, execution_options)

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -19,8 +19,8 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
+from sqlalchemy.sql.base import Executable
 from sqlalchemy.sql.expression import TableClause
-from sqlalchemy.sql.expression import Update
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
@@ -1036,7 +1036,7 @@ def drop_table_comment(
     """
 
 def execute(
-    sqltext: Union[str, TextClause, Update],
+    sqltext: Union[Executable, str],
     *,
     execution_options: Optional[dict[str, Any]] = None,
 ) -> None:
@@ -1105,9 +1105,8 @@ def execute(
     * a string
     * a :func:`sqlalchemy.sql.expression.text` construct.
     * a :func:`sqlalchemy.sql.expression.insert` construct.
-    * a :func:`sqlalchemy.sql.expression.update`,
-      :func:`sqlalchemy.sql.expression.insert`,
-      or :func:`sqlalchemy.sql.expression.delete`  construct.
+    * a :func:`sqlalchemy.sql.expression.update` construct.
+    * a :func:`sqlalchemy.sql.expression.delete` construct.
     * Any "executable" described in SQLAlchemy Core documentation,
       noting that no result set is returned.
 

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -35,10 +35,10 @@ if TYPE_CHECKING:
 
     from sqlalchemy import Table
     from sqlalchemy.engine import Connection
+    from sqlalchemy.sql.base import Executable
     from sqlalchemy.sql.expression import BinaryExpression
     from sqlalchemy.sql.expression import TableClause
     from sqlalchemy.sql.expression import TextClause
-    from sqlalchemy.sql.expression import Update
     from sqlalchemy.sql.functions import Function
     from sqlalchemy.sql.schema import Column
     from sqlalchemy.sql.schema import Computed
@@ -1445,7 +1445,7 @@ class Operations(AbstractOperations):
 
         def execute(
             self,
-            sqltext: Union[str, TextClause, Update],
+            sqltext: Union[Executable, str],
             *,
             execution_options: Optional[dict[str, Any]] = None,
         ) -> None:
@@ -1514,9 +1514,8 @@ class Operations(AbstractOperations):
             * a string
             * a :func:`sqlalchemy.sql.expression.text` construct.
             * a :func:`sqlalchemy.sql.expression.insert` construct.
-            * a :func:`sqlalchemy.sql.expression.update`,
-              :func:`sqlalchemy.sql.expression.insert`,
-              or :func:`sqlalchemy.sql.expression.delete`  construct.
+            * a :func:`sqlalchemy.sql.expression.update` construct.
+            * a :func:`sqlalchemy.sql.expression.delete` construct.
             * Any "executable" described in SQLAlchemy Core documentation,
               noting that no result set is returned.
 
@@ -1842,7 +1841,7 @@ class BatchOperations(AbstractOperations):
 
         def execute(
             self,
-            sqltext: Union[str, TextClause, Update],
+            sqltext: Union[Executable, str],
             *,
             execution_options: Optional[dict[str, Any]] = None,
         ) -> None:

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -28,9 +28,7 @@ from ..util import sqla_compat
 if TYPE_CHECKING:
     from typing import Literal
 
-    from sqlalchemy.sql.dml import Delete
-    from sqlalchemy.sql.dml import Insert
-    from sqlalchemy.sql.dml import Update
+    from sqlalchemy.sql.base import Executable
     from sqlalchemy.sql.elements import BinaryExpression
     from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.elements import conv
@@ -2441,7 +2439,7 @@ class ExecuteSQLOp(MigrateOperation):
 
     def __init__(
         self,
-        sqltext: Union[Delete, Insert, Update, TextClause, str],
+        sqltext: Union[Executable, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -2452,7 +2450,7 @@ class ExecuteSQLOp(MigrateOperation):
     def execute(
         cls,
         operations: Operations,
-        sqltext: Union[Delete, Insert, Update, TextClause, str],
+        sqltext: Union[Executable, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -2543,7 +2541,7 @@ class ExecuteSQLOp(MigrateOperation):
     def batch_execute(
         cls,
         operations: Operations,
-        sqltext: Union[Delete, Insert, Update, TextClause, str],
+        sqltext: Union[Executable, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -28,6 +28,7 @@ from ..util import sqla_compat
 if TYPE_CHECKING:
     from typing import Literal
 
+    from sqlalchemy.sql.dml import Delete
     from sqlalchemy.sql.dml import Insert
     from sqlalchemy.sql.dml import Update
     from sqlalchemy.sql.elements import BinaryExpression
@@ -2440,7 +2441,7 @@ class ExecuteSQLOp(MigrateOperation):
 
     def __init__(
         self,
-        sqltext: Union[Update, str, Insert, TextClause],
+        sqltext: Union[Delete, Insert, Update, TextClause, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -2451,7 +2452,7 @@ class ExecuteSQLOp(MigrateOperation):
     def execute(
         cls,
         operations: Operations,
-        sqltext: Union[str, TextClause, Update],
+        sqltext: Union[Delete, Insert, Update, TextClause, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:
@@ -2520,9 +2521,8 @@ class ExecuteSQLOp(MigrateOperation):
         * a string
         * a :func:`sqlalchemy.sql.expression.text` construct.
         * a :func:`sqlalchemy.sql.expression.insert` construct.
-        * a :func:`sqlalchemy.sql.expression.update`,
-          :func:`sqlalchemy.sql.expression.insert`,
-          or :func:`sqlalchemy.sql.expression.delete`  construct.
+        * a :func:`sqlalchemy.sql.expression.update` construct.
+        * a :func:`sqlalchemy.sql.expression.delete` construct.
         * Any "executable" described in SQLAlchemy Core documentation,
           noting that no result set is returned.
 
@@ -2543,7 +2543,7 @@ class ExecuteSQLOp(MigrateOperation):
     def batch_execute(
         cls,
         operations: Operations,
-        sqltext: Union[str, TextClause, Update],
+        sqltext: Union[Delete, Insert, Update, TextClause, str],
         *,
         execution_options: Optional[dict[str, Any]] = None,
     ) -> None:

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -27,7 +27,7 @@ from ..operations import Operations
 if TYPE_CHECKING:
     from sqlalchemy.engine import URL
     from sqlalchemy.engine.base import Connection
-    from sqlalchemy.sql.elements import ClauseElement
+    from sqlalchemy.sql.base import Executable
     from sqlalchemy.sql.schema import MetaData
     from sqlalchemy.sql.schema import SchemaItem
 
@@ -928,7 +928,7 @@ class EnvironmentContext(util.ModuleClsProxy):
 
     def execute(
         self,
-        sql: Union[ClauseElement, str],
+        sql: Union[Executable, str],
         execution_options: Optional[dict] = None,
     ) -> None:
         """Execute the given SQL using the current change context.

--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine.base import Connection
     from sqlalchemy.engine.base import Transaction
     from sqlalchemy.engine.mock import MockConnection
-    from sqlalchemy.sql.elements import ClauseElement
+    from sqlalchemy.sql.base import Executable
 
     from .environment import EnvironmentContext
     from ..config import Config
@@ -653,7 +653,7 @@ class MigrationContext:
 
     def execute(
         self,
-        sql: Union[ClauseElement, str],
+        sql: Union[Executable, str],
         execution_options: Optional[dict] = None,
     ) -> None:
         """Execute a SQL construct or string statement.

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1074,6 +1074,65 @@ class OpTest(TestBase):
             "FOREIGN KEY(foo_bar) REFERENCES foo (bar))"
         )
 
+    def test_execute_delete(self):
+        context = op_fixture()
+
+        account = table(
+            "account", column("name", String), column("id", Integer)
+        )
+        op.execute(
+            account.delete()
+            .where(account.c.name == "account 1")
+        )
+        context.assert_(
+            "DELETE FROM account WHERE account.name = :name_1",
+        )
+
+    def test_execute_insert(self):
+        context = op_fixture()
+
+        account = table(
+            "account", column("name", String), column("id", Integer)
+        )
+        op.execute(
+            account.insert().values(name="account 1")
+        )
+        context.assert_(
+            "INSERT INTO account (name) VALUES (:name)",
+        )
+
+    def test_execute_update(self):
+        context = op_fixture()
+
+        account = table(
+            "account", column("name", String), column("id", Integer)
+        )
+        op.execute(
+            account.update()
+            .where(account.c.name == "account 1")
+            .values({"name": "account 2"})
+        )
+        context.assert_(
+            "UPDATE account SET name=:name "
+            "WHERE account.name = :name_1",
+        )
+
+    def test_execute_str(self):
+        context = op_fixture()
+
+        op.execute("SELECT 'test'")
+        context.assert_(
+            "SELECT 'test'",
+        )
+
+    def test_execute_textclause(self):
+        context = op_fixture()
+
+        op.execute(text("SELECT 'test'"))
+        context.assert_(
+            "SELECT 'test'",
+        )
+
     def test_inline_literal(self):
         context = op_fixture()
 


### PR DESCRIPTION
### Description
Update type annotation for `sqltext` argument of `op.execute` to support all the documented acceptable types.
Add unit tests for `str` and `TextClause` use cases for `sqltext` argument.
Small repetition cleanup of documentation.
Fixes #1277 

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
