### PR TITLE
Fixes #1300: Inability to pass an ExcludeConstraint object to DropConstraint.from_constraint

### DIFF
--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -164,6 +164,7 @@ class DropConstraintOp(MigrateOperation):
             "check_constraint": "check",
             "column_check_constraint": "check",
             "table_or_column_check_constraint": "check",
+            "exclude_constraint": "exclude",
         }
 
         constraint_table = sqla_compat._table_for_constraint(constraint)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1258,6 +1258,30 @@ class PostgresqlAutogenRenderTest(TestBase):
             "name='TExclID'))",
         )
 
+    def test_drop_exclude_constraint(self):
+        """test for #1300"""
+
+        autogen_context = self.autogen_context
+
+        m = MetaData()
+        t = Table(
+            "TTable", m, Column("XColumn", String), Column("YColumn", String)
+        )
+
+        op_obj = ops.DropConstraintOp.from_constraint(
+            ExcludeConstraint(
+                (t.c.XColumn, ">"),
+                where=t.c.XColumn != 2,
+                using="gist",
+                name="t_excl_x",
+            )
+        )
+
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(autogen_context, op_obj),
+            "op.drop_constraint('t_excl_x', 'TTable',  type_='exclude')",
+        )
+
     def test_json_type(self):
         eq_ignore_whitespace(
             autogenerate.render._repr_type(JSON(), self.autogen_context),


### PR DESCRIPTION
Addresses issue #1300 - inability to pass an ExcludeConstraint object to DropConstraint.from_constraint

### Description
Adds support for ExcludeConstraint being passed to DropConstraint.from_constraint

### Checklist

This pull request is:

- [X] A bug fix for an issue (#1300)
- [X] A short code fix
- [X] Includes a unit test
