### PR TITLE
Add `match` keyword argument to rendering of foreign key constraints

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -367,6 +367,7 @@ def _add_fk_constraint(
         "initially",
         "deferrable",
         "use_alter",
+        "match",
     ]
     if not autogen_context._has_batch:
         kwargs.insert(0, "source_schema")
@@ -977,6 +978,8 @@ def _populate_render_fk_opts(
         opts.append(("deferrable", repr(constraint.deferrable)))
     if constraint.use_alter:
         opts.append(("use_alter", repr(constraint.use_alter)))
+    if constraint.match:
+        opts.append(("match", repr(constraint.match)))
 
 
 @_constraint_renderers.dispatch_for(sa_schema.ForeignKeyConstraint)

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -545,6 +545,8 @@ class CreateForeignKeyOp(AddConstraintOp):
             kw["deferrable"] = fk_constraint.deferrable
         if fk_constraint.use_alter:
             kw["use_alter"] = fk_constraint.use_alter
+        if fk_constraint.match:
+            kw["match"] = fk_constraint.match
 
         (
             source_schema,

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -1388,12 +1388,25 @@ class AutogenRenderTest(TestBase):
             "sa.ForeignKeyConstraint(['c'], ['t2.c_rem'], initially='XYZ')",
         )
 
+        fk = ForeignKeyConstraint([t1.c.c], [t2.c.c_rem], match="FULL")
+        eq_ignore_whitespace(
+            re.sub(
+                r"u'",
+                "'",
+                autogenerate.render._render_constraint(
+                    fk, self.autogen_context, m
+                ),
+            ),
+            "sa.ForeignKeyConstraint(['c'], ['t2.c_rem'], match='FULL')",
+        )
+
         fk = ForeignKeyConstraint(
             [t1.c.c],
             [t2.c.c_rem],
             initially="XYZ",
             ondelete="CASCADE",
             deferrable=True,
+            match="FULL",
         )
         eq_ignore_whitespace(
             re.sub(
@@ -1404,7 +1417,8 @@ class AutogenRenderTest(TestBase):
                 ),
             ),
             "sa.ForeignKeyConstraint(['c'], ['t2.c_rem'], "
-            "ondelete='CASCADE', initially='XYZ', deferrable=True)",
+            "ondelete='CASCADE', initially='XYZ', deferrable=True, "
+            "match='FULL')",
         )
 
     def test_render_fk_constraint_resolve_key(self):

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -480,12 +480,25 @@ class AutogenRenderTest(TestBase):
             "initially='XYZ')",
         )
 
+        fk = ForeignKeyConstraint([t1.c.c], [t2.c.c_rem], match="FULL")
+        op_obj = ops.AddConstraintOp.from_constraint(fk)
+        eq_ignore_whitespace(
+            re.sub(
+                r"u'",
+                "'",
+                autogenerate.render_op_text(self.autogen_context, op_obj),
+            ),
+            "op.create_foreign_key(None, 't', 't2', ['c'], ['c_rem'], "
+            "match='FULL')",
+        )
+
         fk = ForeignKeyConstraint(
             [t1.c.c],
             [t2.c.c_rem],
             initially="XYZ",
             ondelete="CASCADE",
             deferrable=True,
+            match="FULL",
         )
         op_obj = ops.AddConstraintOp.from_constraint(fk)
         eq_ignore_whitespace(
@@ -495,7 +508,8 @@ class AutogenRenderTest(TestBase):
                 autogenerate.render_op_text(self.autogen_context, op_obj),
             ),
             "op.create_foreign_key(None, 't', 't2', ['c'], ['c_rem'], "
-            "ondelete='CASCADE', initially='XYZ', deferrable=True)",
+            "ondelete='CASCADE', initially='XYZ', deferrable=True, "
+            "match='FULL')",
         )
 
     def test_add_fk_constraint_inline_colkeys(self):


### PR DESCRIPTION
Fixes: #1302 

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
- Added `match` keyword at converting a `ForeignKeyConstraint` to a `CreateForeignKeyOp`
- Added `match` keyword at rendering of `ForeignKeyConstraint`
- Added `match` keyword at rendering of `CreateForeignKeyOp`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
