### PR TITLE
setup.cfg Project Links: added Changelog + reorder

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Database :: Front-Ends
 project_urls =
-    Source = https://github.com/sqlalchemy/alembic/
     Documentation = https://alembic.sqlalchemy.org/en/latest/
+    Changelog = https://alembic.sqlalchemy.org/en/latest/changelog.html
+    Source = https://github.com/sqlalchemy/alembic/
     Issue Tracker = https://github.com/sqlalchemy/alembic/issues/
-
 [options]
 packages = find_namespace:
 include_package_data = true


### PR DESCRIPTION
Python package metadata got additional link to Changelog.

### Description
Package urls got additional url for Changelog.

Order of links was also changed to go from the most general to the most specific:
-  Documentation
-  Changelog
-  Source
- Issue Tracker

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
