### PR TITLE
Improve handling of prepend_sys_path, fixes #1330

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -339,6 +339,27 @@ class Config:
             ),
         )
 
+    def get_separator_char(self, name: str) -> Optional[str]:
+        separator = self.get_main_option(name)
+
+        split_on_path = {
+            None: None,
+            "space": " ",
+            "newline": "\n",
+            "os": os.pathsep,
+            ":": ":",
+            ";": ";",
+        }
+
+        try:
+            return split_on_path[separator]
+        except KeyError as ke:
+            raise ValueError(
+                "'%s' is not a valid value for %s; "
+                "expected 'space', 'newline', 'os', ':', ';'"
+                % (separator, name)
+            ) from ke
+
 
 class MessagingOptions(TypedDict, total=False):
     quiet: bool

--- a/alembic/script/base.py
+++ b/alembic/script/base.py
@@ -221,9 +221,12 @@ class ScriptDirectory:
 
         prepend_sys_path = config.get_main_option("prepend_sys_path")
         if prepend_sys_path:
-            sys.path[:0] = list(
-                _split_on_space_comma_colon.split(prepend_sys_path)
-            )
+            if os.name == 'nt':
+                prepend_paths = _split_on_space_comma.split(prepend_sys_path)
+            else:
+                prepend_paths = _split_on_space_comma_colon.split(prepend_sys_path)
+            
+            sys.path[:0] = (os.path.normpath(path.strip()) for path in prepend_paths)
 
         rvl = config.get_main_option("recursive_version_locations") == "true"
         return ScriptDirectory(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
* If `os.name` equals `'nt`' then don't split using colons
* Split on any whitespace, not just the `' '` character so people can break up long lists into multiple lines.
* Also normalize and trim paths to prevent issues with the previous point.

Fixes: #1330 

~~**How should I test this?**~~ Added unit tests.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
