### PR TITLE
Fix typing of `revision` argument in "Don't Generate Empty Migrations with Autogenerate" recipe

### DIFF
--- a/docs/build/cookbook.rst
+++ b/docs/build/cookbook.rst
@@ -901,6 +901,7 @@ single :class:`.MigrationScript` directive if it is empty of
 any operations::
 
     # for typing purposes
+    from collections.abc import Iterable
     from alembic.environment import MigrationContext
 
     # this typing-only import requires alembic 1.12.1 or above
@@ -913,7 +914,7 @@ any operations::
 
         def process_revision_directives(
             context: MigrationContext,
-            revision: tuple[str, str],
+            revision: str | Iterable[str | None] | Iterable[str],
             directives: list[MigrationScript],
         ):
             assert config.cmd_opts is not None


### PR DESCRIPTION
### Description

Type-annotations were added to the "Don't Generate Empty Migrations with Autogenerate" cookbook recipe in commit 3e48ed0.  Later, in commit 222e4ba, the type of the `revision` argument to `process_revision_directives()` was changed from `tuple[str, str]` to `str | Iterable[str | None] | Iterable[str]`, but the recipe was not updated.  This PR updates the recipe so that it will type-check.

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.