### PR TITLE
Open up `if_(not_)?exists` to SQLAlchemy 1.4+

### DIFF
--- a/alembic/operations/toimpl.py
+++ b/alembic/operations/toimpl.py
@@ -5,7 +5,7 @@ from sqlalchemy import schema as sa_schema
 from . import ops
 from .base import Operations
 from ..util.sqla_compat import _copy
-from ..util.sqla_compat import sqla_2
+from ..util.sqla_compat import sqla_14
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.schema import Table
@@ -98,8 +98,8 @@ def create_index(
     idx = operation.to_index(operations.migration_context)
     kw = {}
     if operation.if_not_exists is not None:
-        if not sqla_2:
-            raise NotImplementedError("SQLAlchemy 2.0+ required")
+        if not sqla_14:
+            raise NotImplementedError("SQLAlchemy 1.4+ required")
 
         kw["if_not_exists"] = operation.if_not_exists
     operations.impl.create_index(idx, **kw)
@@ -109,8 +109,8 @@ def create_index(
 def drop_index(operations: "Operations", operation: "ops.DropIndexOp") -> None:
     kw = {}
     if operation.if_exists is not None:
-        if not sqla_2:
-            raise NotImplementedError("SQLAlchemy 2.0+ required")
+        if not sqla_14:
+            raise NotImplementedError("SQLAlchemy 1.4+ required")
 
         kw["if_exists"] = operation.if_exists
 

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -829,7 +829,7 @@ class OpTest(TestBase):
         op.create_index("ik_test", "t1", ["foo", "bar"])
         context.assert_("CREATE INDEX ik_test ON t1 (foo, bar)")
 
-    @config.requirements.sqlalchemy_2
+    @config.requirements.sqlalchemy_14
     def test_create_index_if_not_exists(self):
         context = op_fixture()
         op.create_index("ik_test", "t1", ["foo", "bar"], if_not_exists=True)
@@ -891,7 +891,7 @@ class OpTest(TestBase):
         op.drop_index("ik_test", schema="foo")
         context.assert_("DROP INDEX foo.ik_test")
 
-    @config.requirements.sqlalchemy_2
+    @config.requirements.sqlalchemy_14
     def test_drop_index_if_exists(self):
         context = op_fixture()
         op.drop_index("ik_test", if_exists=True)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -122,7 +122,7 @@ class PostgresqlOpTest(TestBase):
         op.create_index("i", "t", ["c1", "c2"], unique=False)
         context.assert_("CREATE INDEX i ON t (c1, c2)")
 
-    @config.requirements.sqlalchemy_2
+    @config.requirements.sqlalchemy_14
     def test_create_index_postgresql_if_not_exists(self):
         context = op_fixture("postgresql")
         op.create_index("i", "t", ["c1", "c2"], if_not_exists=True)
@@ -141,7 +141,7 @@ class PostgresqlOpTest(TestBase):
             op.drop_index("geocoded", postgresql_concurrently=True)
         context.assert_("DROP INDEX CONCURRENTLY geocoded")
 
-    @config.requirements.sqlalchemy_2
+    @config.requirements.sqlalchemy_14
     def test_drop_index_postgresql_if_exists(self):
         context = op_fixture("postgresql")
         op.drop_index("geocoded", if_exists=True)


### PR DESCRIPTION
Fixes #1323

### Description
As the title describes, open up `if_(not_)?exists` support (both implementations and tests) to SQLAlchemy 1.4+

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.