### PR TITLE
Fix `get_x_arguments(as_dictionary=True)` for args without `=`

### DIFF
--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -762,6 +762,9 @@ def get_x_argument(
     then returned. If there is no `=` in the argument, value is an empty
     string.
 
+    .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
+    without `=`, generating an empty string instead of crashing.
+
     For example, to support passing a database URL on the command line,
     the standard ``env.py`` script can be modified like this::
 

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -762,7 +762,7 @@ def get_x_argument(
     then returned. If there is no `=` in the argument, value is an empty
     string.
 
-    .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
+    .. versionchanged:: 1.13.1 Support to `as_dictionary=True` and args
        without `=`, generating an empty string instead of crashing.
 
     For example, to support passing a database URL on the command line,

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -763,7 +763,7 @@ def get_x_argument(
     string.
 
     .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
-    without `=`, generating an empty string instead of crashing.
+       without `=`, generating an empty string instead of crashing.
 
     For example, to support passing a database URL on the command line,
     the standard ``env.py`` script can be modified like this::

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -759,7 +759,8 @@ def get_x_argument(
     The return value is a list, returned directly from the ``argparse``
     structure.  If ``as_dictionary=True`` is passed, the ``x`` arguments
     are parsed using ``key=value`` format into a dictionary that is
-    then returned.
+    then returned. If there is no `=` in the argument, value is an empty
+    string.
 
     For example, to support passing a database URL on the command line,
     the standard ``env.py`` script can be modified like this::

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -370,7 +370,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         then returned. If there is no `=` in the argument, value is an empty
         string.
 
-        .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
+        .. versionchanged:: 1.13.1 Support to `as_dictionary=True` and args
            without `=`, generating an empty string instead of crashing.
 
         For example, to support passing a database URL on the command line,

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -371,7 +371,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         string.
 
         .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
-        without `=`, generating an empty string instead of crashing.
+           without `=`, generating an empty string instead of crashing.
 
         For example, to support passing a database URL on the command line,
         the standard ``env.py`` script can be modified like this::

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -367,7 +367,8 @@ class EnvironmentContext(util.ModuleClsProxy):
         The return value is a list, returned directly from the ``argparse``
         structure.  If ``as_dictionary=True`` is passed, the ``x`` arguments
         are parsed using ``key=value`` format into a dictionary that is
-        then returned.
+        then returned. If there is no `=` in the argument, value is an empty
+        string.
 
         For example, to support passing a database URL on the command line,
         the standard ``env.py`` script can be modified like this::
@@ -401,7 +402,15 @@ class EnvironmentContext(util.ModuleClsProxy):
         else:
             value = []
         if as_dictionary:
-            value = dict(arg.split("=", 1) for arg in value)
+            dict_value = {}
+            for arg in value:
+                try:
+                    x_key, x_value = arg.split("=", 1)
+                except ValueError:
+                    x_key, x_value = arg, ""
+                dict_value[x_key] = x_value
+            value = dict_value
+
         return value
 
     def configure(

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -404,10 +404,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         if as_dictionary:
             dict_value = {}
             for arg in value:
-                try:
-                    x_key, x_value = arg.split("=", 1)
-                except ValueError:
-                    x_key, x_value = arg, ""
+                x_key, _, x_value = arg.partition("=")
                 dict_value[x_key] = x_value
             value = dict_value
 

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -370,6 +370,9 @@ class EnvironmentContext(util.ModuleClsProxy):
         then returned. If there is no `=` in the argument, value is an empty
         string.
 
+        .. versionchanged:: 1.13.0 Support to `as_dictionary=True` and args
+        without `=`, generating an empty string instead of crashing.
+
         For example, to support passing a database URL on the command line,
         the standard ``env.py`` script can be modified like this::
 

--- a/docs/build/unreleased/1370.rst
+++ b/docs/build/unreleased/1370.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, autogenerate
+    :tickets: 1370
+
+    Fixed issue with ``get_x_arguments(as_dictionary=True)`` and args without
+    ``=``. Now args without ``=`` are supported and generate an empty string as
+    their value.

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -54,6 +54,11 @@ class EnvironmentTest(TestBase):
         env = self._fixture()
         eq_(env.get_x_argument(as_dictionary=True), {})
 
+    def test_x_arg_empty_value(self):
+        env = self._fixture()
+        self.cfg.cmd_opts = mock.Mock(x=["y"])
+        eq_(env.get_x_argument(as_dictionary=True), {"y": ""})
+
     def test_tag_arg(self):
         env = self._fixture(tag="x")
         eq_(env.get_tag_argument(), "x")


### PR DESCRIPTION
Fix #1369 

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
