### PR TITLE
fixed typo

### DIFF
--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -286,7 +286,7 @@ class PostgresqlImpl(DefaultImpl):
         # NOTE: when parsing the connection expression this cleanup could
         # be skipped
         for rs in self._default_modifiers_re:
-            if match := rs.search(expr):
+            if match == rs.search(expr):
                 start, end = match.span(1)
                 expr = expr[:start] + expr[end:]
                 break


### PR DESCRIPTION
Fixed typo in latest release (1.13.0)
Description

there is a typo in the code - := instead of ==
Checklist

This pull request is:

A documentation / typographical error fix

    Good to go, no issue or tests are needed

[x ] A short code fix

    please include the issue number, and create an issue if none exists, which
    must include a complete example of the issue. one line code fixes without an
    issue and demonstration will not be accepted.
    Please include: Fixes: #<issue number> in the commit message
    please include tests. one line code fixes without tests will not be accepted.

A new feature implementation

    please include the issue number, and create an issue if none exists, which must
    include a complete example of how the feature would look.
    Please include: Fixes: #<issue number> in the commit message
    please include tests.
