### PR TITLE
fix alembic.util.messaging.msg to properly wrap at terminal width

### DIFF
--- a/alembic/util/messaging.py
+++ b/alembic/util/messaging.py
@@ -95,11 +95,17 @@ def msg(
             write_outstream(sys.stdout, "\n")
     else:
         # left indent output lines
-        lines = textwrap.wrap(msg, TERMWIDTH)
+        indent = "  "
+        lines = textwrap.wrap(
+            msg,
+            TERMWIDTH,
+            initial_indent=indent,
+            subsequent_indent=indent,
+        )
         if len(lines) > 1:
             for line in lines[0:-1]:
-                write_outstream(sys.stdout, "  ", line, "\n")
-        write_outstream(sys.stdout, "  ", lines[-1], ("\n" if newline else ""))
+                write_outstream(sys.stdout, line, "\n")
+        write_outstream(sys.stdout, lines[-1], ("\n" if newline else ""))
     if flush:
         sys.stdout.flush()
 

--- a/docs/build/unreleased/1384.rst
+++ b/docs/build/unreleased/1384.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, commands
+    :tickets: 1384
+
+    Fixed bug in alembic command stdout where long messages were not properly
+    wrapping at the terminal width.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -323,12 +323,6 @@ class CurrentTest(_BufMixin, TestBase):
         with self._assert_lines(["a3"]):
             command.current(self.cfg)
 
-    def test_current_obfuscate_password(self):
-        eq_(
-            util.obfuscate_url_pw("postgresql://scott:tiger@localhost/test"),
-            "postgresql://scott:***@localhost/test",
-        )
-
     def test_two_heads(self):
         command.stamp(self.cfg, ())
         command.stamp(self.cfg, (self.a1.revision, self.b1.revision))

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,0 +1,27 @@
+from io import StringIO
+
+from alembic.testing import eq_
+from alembic.testing import mock
+from alembic.testing.fixtures import TestBase
+from alembic.util.messaging import msg
+from alembic.util.messaging import obfuscate_url_pw
+
+
+class MessagingTest(TestBase):
+    def test_msg_wraps(self):
+        buf = StringIO()
+        with mock.patch("sys.stdout", buf), mock.patch(
+            "alembic.util.messaging.TERMWIDTH", 10
+        ):
+            msg("AAAAAAAAAAAAAAAAA")
+        assert str(buf.getvalue()).splitlines() == [
+            "  AAAAAAAA",  # initial indent with 10 chars before wrapping
+            "  AAAAAAAA",  # subsequent indent with 10 chars before wrapping
+            "  A",  # subsequent indent with remainining chars
+        ]
+
+    def test_current_obfuscate_password(self):
+        eq_(
+            obfuscate_url_pw("postgresql://scott:tiger@localhost/test"),
+            "postgresql://scott:***@localhost/test",
+        )


### PR DESCRIPTION
### Description
Instead of applying indent manually after using textwrap, simply use the `textwrap.wrap`'s `initial_indent` / `subsequent_indent` so that it is accounted for when wrapping to `width`.

Otherwise, each line will actually exceed the terminal width by two characters, since we were prepending two spaces.

Fixes: #1384


### Manual Testing

Running the repro in #1384 now produces the expected output:
> In a fairly narrow terminal window (e.g. 64 columns wide), run:
> ```py
> python -c 'from alembic.util.messaging import msg; msg("A" * 500)'
> ```

Output:
```
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
  AAAA
```
🎉 


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
