### PR TITLE
render type.impl when type is a TypeDecorator instance

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -834,7 +834,7 @@ def _repr_type(
             prefix = _sqlalchemy_autogenerate_prefix(autogen_context)
             return "%s%r" % (prefix, type_)
     elif isinstance(type_, sqltypes.TypeDecorator):
-        return _repr_type(type_.impl_instance, autogen_context, _skip_variants)
+        return _repr_type(cast("TypeEngine", type_.impl), autogen_context, _skip_variants)
     else:
         prefix = _user_autogenerate_prefix(autogen_context, type_)
         return "%s%r" % (prefix, type_)

--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -803,9 +803,6 @@ def _repr_type(
     if rendered is not False:
         return rendered
 
-    if isinstance(type_, sqltypes.TypeDecorator):
-        type_ = type_.impl
-
     if hasattr(autogen_context.migration_context, "impl"):
         impl_rt = autogen_context.migration_context.impl.render_type(
             type_, autogen_context
@@ -836,6 +833,8 @@ def _repr_type(
         else:
             prefix = _sqlalchemy_autogenerate_prefix(autogen_context)
             return "%s%r" % (prefix, type_)
+    elif isinstance(type_, sqltypes.TypeDecorator):
+        return _repr_type(type_.impl_instance, autogen_context, _skip_variants)
     else:
         prefix = _user_autogenerate_prefix(autogen_context, type_)
         return "%s%r" % (prefix, type_)

--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -803,6 +803,9 @@ def _repr_type(
     if rendered is not False:
         return rendered
 
+    if isinstance(type_, sqltypes.TypeDecorator):
+        type_ = type_.impl
+
     if hasattr(autogen_context.migration_context, "impl"):
         impl_rt = autogen_context.migration_context.impl.render_type(
             type_, autogen_context

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql import false
 from sqlalchemy.sql import literal_column
 from sqlalchemy.sql import table
 from sqlalchemy.types import TIMESTAMP
+from sqlalchemy.types import TypeDecorator
 from sqlalchemy.types import UserDefinedType
 
 from alembic import autogenerate
@@ -1071,6 +1072,21 @@ class AutogenRenderTest(TestBase):
     def test_render_add_column(self):
         op_obj = ops.AddColumnOp(
             "foo", Column("x", Integer, server_default="5")
+        )
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.add_column('foo', sa.Column('x', sa.Integer(), "
+            "server_default='5', nullable=True))",
+        )
+
+    def test_render_add_column_type_decorator(self):
+        self.autogen_context.opts["user_module_prefix"] = None
+
+        class MyType(TypeDecorator):
+            impl = Integer
+
+        op_obj = ops.AddColumnOp(
+            "foo", Column("x", MyType, server_default="5")
         )
         eq_ignore_whitespace(
             autogenerate.render_op_text(self.autogen_context, op_obj),


### PR DESCRIPTION
### Description
When rendering the type, we check to see if we are dealing with a TypeDecorator, and if so, proceed but with type.impl instead... this results in the underlying type from the sqlalchemy package to be rendered into the migration instead of the TypeDecorator (wherever it may be defined).

Fixes: #1386

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
