### PR TITLE
Ignore newlines in expressions for Computed

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -983,7 +983,7 @@ def _normalize_computed_default(sqltext: str) -> str:
 
     """
 
-    return re.sub(r"[ \(\)'\"`\[\]]", "", sqltext).lower()
+    return re.sub(r"[ \(\)'\"`\[\]\t\r\n]", "", sqltext).lower()
 
 
 def _compare_computed_default(

--- a/alembic/testing/suite/test_autogen_computed.py
+++ b/alembic/testing/suite/test_autogen_computed.py
@@ -124,6 +124,7 @@ class AutogenerateComputedTest(AutogenFixtureTest, TestBase):
         lambda: (None, None),
         lambda: (sa.Computed("5"), sa.Computed("5")),
         lambda: (sa.Computed("bar*5"), sa.Computed("bar*5")),
+        lambda: (sa.Computed("bar*5"), sa.Computed("bar * \r\n\t5")),
         (
             lambda: (sa.Computed("bar*5"), None),
             config.requirements.computed_doesnt_reflect_as_server_default,


### PR DESCRIPTION
Fixes #1391

There's already a function that normalizes expressions from generated columns and server defaults. It looks like this:

```py
def _normalize_computed_default(sqltext: str) -> str:
    """we want to warn if a computed sql expression has changed.  however
    we don't want false positives and the warning is not that critical.
    so filter out most forms of variability from the SQL text.

    """

    return re.sub(r"[ \(\)'\"`\[\]]", "", sqltext).lower()
```

I added the characters `\r\n\t` to the ones that are removed.

### Description

I added the characters `\r\n\t` to the regex that normalizes the expressions, that's it. Also added a test case.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
