### PR TITLE
Fix type annotations in create_foreign_key

### DIFF
--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -1721,7 +1721,7 @@ class BatchOperations(AbstractOperations):
 
         def create_foreign_key(
             self,
-            constraint_name: str,
+            constraint_name: Optional[str],
             referent_table: str,
             local_cols: List[str],
             remote_cols: List[str],

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -681,7 +681,7 @@ class CreateForeignKeyOp(AddConstraintOp):
     def batch_create_foreign_key(
         cls,
         operations: BatchOperations,
-        constraint_name: str,
+        constraint_name: Optional[str],
         referent_table: str,
         local_cols: List[str],
         remote_cols: List[str],


### PR DESCRIPTION
### Description
The constraint name parameter of create_foreign_key should be optional, but the batch function defined it as str instead of Optional[str].

Closes #1429

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
