### PR TITLE
Render `if_not_exists`  option for CreateIndexOp and DropIndexOp

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -324,6 +324,8 @@ def _add_index(autogen_context: AutogenContext, op: ops.CreateIndexOp) -> str:
     assert index.table is not None
 
     opts = _render_dialect_kwargs_items(autogen_context, index)
+    if op.if_not_exists is not None:
+        opts.append("if_not_exists=%r" % bool(op.if_not_exists))
     text = tmpl % {
         "prefix": _alembic_autogenerate_prefix(autogen_context),
         "name": _render_gen_name(autogen_context, index.name),
@@ -356,6 +358,8 @@ def _drop_index(autogen_context: AutogenContext, op: ops.DropIndexOp) -> str:
             "table_name=%(table_name)r%(schema)s%(kwargs)s)"
         )
     opts = _render_dialect_kwargs_items(autogen_context, index)
+    if op.if_exists is not None:
+        opts.append("if_exists=%r" % bool(op.if_exists))
     text = tmpl % {
         "prefix": _alembic_autogenerate_prefix(autogen_context),
         "name": _render_gen_name(autogen_context, op.index_name),

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -93,6 +93,20 @@ class AutogenRenderTest(TestBase):
             "['active', 'code'], unique=False)",
         )
 
+    def test_render_add_index_if_not_exists(self):
+        """
+        autogenerate.render._add_index
+        """
+        t = self.table()
+        idx = Index("test_active_code_idx", t.c.active, t.c.code)
+        op_obj = ops.CreateIndexOp.from_index(idx)
+        op_obj.if_not_exists = True
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.create_index('test_active_code_idx', 'test', "
+            "['active', 'code'], unique=False, if_not_exists=True)",
+        )
+
     @testing.emits_warning("Can't validate argument ")
     def test_render_add_index_custom_kwarg(self):
         t = self.table()
@@ -210,6 +224,19 @@ class AutogenRenderTest(TestBase):
         eq_ignore_whitespace(
             autogenerate.render_op_text(self.autogen_context, op_obj),
             "op.drop_index('test_active_code_idx', table_name='test')",
+        )
+
+    def test_drop_index_if_exists(self):
+        """
+        autogenerate.render._drop_index
+        """
+        t = self.table()
+        idx = Index("test_active_code_idx", t.c.active, t.c.code)
+        op_obj = ops.DropIndexOp.from_index(idx)
+        op_obj.if_exists = True
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.drop_index('test_active_code_idx', table_name='test', if_exists=True)",
         )
 
     def test_drop_index_text(self):


### PR DESCRIPTION
Fixes: #151

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Without opinion on whether or not the option `if_not_exists` or `if_exists` should be set by default (or configurable via AutogenContext), I think a follow-up on 
#151 should be that `if_not_exists` or `if_exists` attributes should be that they are rendered during autogen steps.

How I intend to use it: specify the attribute during rewrites of the pipeline

```python
@writer.rewrites(ops.CreateIndexOp)
def create_index_if_not_exist(_autogen_context, _revision, op: ops.CreateIndexOp):
    op.if_not_exists = True
    return op


@writer.rewrites(ops.DropIndexOp)
def drop_index_if_exist(_autogen_context, _revision, op: ops.DropIndexOp):
    op.if_exists = True
    return op
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
