### PR TITLE
Fix constraint_name type in create_primary_key

### DIFF
--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -1771,7 +1771,7 @@ class BatchOperations(AbstractOperations):
             ...
 
         def create_primary_key(
-            self, constraint_name: str, columns: List[str]
+            self, constraint_name: Optional[str], columns: List[str]
         ) -> None:
             """Issue a "create primary key" instruction using the
             current batch migration context.


### PR DESCRIPTION
The constraint name in create_primary_key should be optional, but for batch operations is is required according to the type annotations

### Description
Changed the type annotation to `Optional[str]`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
