### PR TITLE
Fix postgres detect serial in autogenerate (#1479)

### DIFF
--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -218,7 +218,8 @@ class PostgresqlImpl(DefaultImpl):
                         "join pg_class t on t.oid=d.refobjid "
                         "join pg_attribute a on a.attrelid=t.oid and "
                         "a.attnum=d.refobjsubid "
-                        "where c.relkind='S' and c.relname=:seqname"
+                        "where c.relkind='S' and "
+                        "c.oid=cast(:seqname as regclass)"
                     ),
                     seqname=seq_match.group(1),
                 ).first()

--- a/docs/build/unreleased/1479.rst
+++ b/docs/build/unreleased/1479.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, autogenerate, postgresql
+    :tickets: 1479
+
+    Fixed the detection of serial column in autogenerate with tables
+    not under default schema on PostgreSQL


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes: https://github.com/sqlalchemy/alembic/issues/1479

### Description
<!-- Describe your changes in detail -->
In https://github.com/sqlalchemy/alembic/issues/73, it tries to detact postgresql serial in autogenerate, so it won't take `nextval('seq'::regclass)` as server default for that column.
But it takes not effect for tables not in search path. This PR fixed it.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
