### PR TITLE
Improve write_pyi usage

### DIFF
--- a/tools/write_pyi.py
+++ b/tools/write_pyi.py
@@ -11,11 +11,11 @@ from tempfile import NamedTemporaryFile
 import textwrap
 import typing
 
+sys.path.append(str(Path(__file__).parent.parent))
+
 from alembic.autogenerate.api import AutogenContext
 from alembic.ddl.impl import DefaultImpl
 from alembic.runtime.migration import MigrationInfo
-
-sys.path.append(str(Path(__file__).parent.parent))
 
 if True:  # avoid flake/zimports messing with the order
     from alembic.operations.base import BatchOperations

--- a/tox.ini
+++ b/tox.ini
@@ -101,3 +101,12 @@ deps=
 commands =
      flake8 ./alembic/ ./tests/ setup.py docs/build/conf.py {posargs}
      black --check setup.py tests alembic
+
+[testenv:write_pyi]
+basepython = python3
+deps=
+    sqlalchemy>=2
+    mako
+    zimports
+    black==24.1.1
+commands = python tools/write_pyi.py


### PR DESCRIPTION
Fixes #1524
### Description

Due to some problems when running write_pyi, this includes the following changes:

1. move the sys.path.append up before alembic is imported - this is using global imports otherwise
2. use tox to run write_pyi in order to avoid globally installed dependencies


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
