### PR TITLE
Update tutorial.rst for ruff post_write_hooks

### DIFF
--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -204,7 +204,7 @@ The file generated with the "generic" configuration looks like::
     # hooks = ruff
     # ruff.type = exec
     # ruff.executable = %(here)s/.venv/bin/ruff
-    # ruff.options = --fix REVISION_SCRIPT_FILENAME
+    # ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
     # Logging configuration
     [loggers]


### PR DESCRIPTION
Due ruff package update - `ruff <path>` has been removed. Use `ruff check <path>` instead.

### Description
Due ruff package update in new versions, command `ruff <path>` has been removed. Use `ruff check <path>` instead. Example in tutorial will be not work for new ruff versions

### Checklist
This pull request is:

- [x] A documentation / typographical error fix

