### PR TITLE
Add colon (:) to invalid char for revision name

### DIFF
--- a/alembic/script/revision.py
+++ b/alembic/script/revision.py
@@ -45,7 +45,7 @@ _T = TypeVar("_T")
 _TR = TypeVar("_TR", bound=Optional[_RevisionOrStr])
 
 _relative_destination = re.compile(r"(?:(.+?)@)?(\w+)?((?:\+|-)\d+)")
-_revision_illegal_chars = ["@", "-", "+"]
+_revision_illegal_chars = ["@", "-", "+", ":"]
 
 
 class _CollectRevisionsProtocol(Protocol):


### PR DESCRIPTION
FIXES #1540 

### Description
As colon is used in revision range, it shouldn't be used in revision name.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
