### PR TITLE
fix: Correct the AutogenContext.metadata typing to include Sequence[MetaData].

### DIFF
--- a/alembic/autogenerate/api.py
+++ b/alembic/autogenerate/api.py
@@ -277,7 +277,7 @@ class AutogenContext:
     """Maintains configuration and state that's specific to an
     autogenerate operation."""
 
-    metadata: Optional[MetaData] = None
+    metadata: Union[MetaData, Sequence[MetaData], None] = None
     """The :class:`~sqlalchemy.schema.MetaData` object
     representing the destination.
 
@@ -332,7 +332,7 @@ class AutogenContext:
     def __init__(
         self,
         migration_context: MigrationContext,
-        metadata: Optional[MetaData] = None,
+        metadata: Union[MetaData, Sequence[MetaData], None] = None,
         opts: Optional[Dict[str, Any]] = None,
         autogenerate: bool = True,
     ) -> None:


### PR DESCRIPTION
### Description
The type annotation for AutogenContext.metadata is currently `Optional[MetaData]`, but `target_metadata` is `Union[MetaData, Sequence[MetaData], None]`. Seems like setting `target_metadata` to `[]` directly translates into the list that `AutogenContext` receives, and that the code is already coercing the potential single/sequence to always be a list.

My alembic plugin wasn't aware that this **could** be a list, and as such wasn't handling the possibility properly.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
