### PR TITLE
Use logging.WARNING instead of logging.WARN

### DIFF
--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -90,12 +90,12 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
+level = WARNING
 handlers =
 qualname = sqlalchemy.engine
 

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -92,12 +92,12 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
+level = WARNING
 handlers =
 qualname = sqlalchemy.engine
 

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -97,12 +97,12 @@ keys = console
 keys = generic
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
 [logger_sqlalchemy]
-level = WARN
+level = WARNING
 handlers =
 qualname = sqlalchemy.engine
 

--- a/alembic/testing/env.py
+++ b/alembic/testing/env.py
@@ -118,7 +118,7 @@ keys = root,sqlalchemy
 keys = console
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
@@ -171,7 +171,7 @@ keys = root
 keys = console
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
@@ -216,7 +216,7 @@ keys = root
 keys = console
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 
@@ -497,7 +497,7 @@ keys = root
 keys = console
 
 [logger_root]
-level = WARN
+level = WARNING
 handlers = console
 qualname =
 

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -217,12 +217,12 @@ The file generated with the "generic" configuration looks like::
     keys = generic
 
     [logger_root]
-    level = WARN
+    level = WARNING
     handlers = console
     qualname =
 
     [logger_sqlalchemy]
-    level = WARN
+    level = WARNING
     handlers =
     qualname = sqlalchemy.engine
 


### PR DESCRIPTION
The `WARN` constant is an undocumented alias for `WARNING`. Whilst it’s not deprecated, it’s not mentioned at all in the documentation. This references one of  `flake8-logging` plugins [rule](https://github.com/adamchainz/flake8-logging?tab=readme-ov-file#log009-warn-is-undocumented-use-warning-instead).

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Changed all uses of `logging.WARN` to `logging.WARNING`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
