### PR TITLE
fix(requirements): add `tzdata` to `tz` extras; fixes #1556

### DIFF
--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -15,7 +15,7 @@ prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.
-# If specified, requires the python>=3.9 or backports.zoneinfo library.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
 # Any required deps can installed by adding `alembic[tz]` to the pip requirements
 # string value is passed to ZoneInfo()
 # leave blank for localtime

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -17,7 +17,7 @@ prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.
-# If specified, requires the python>=3.9 or backports.zoneinfo library.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
 # Any required deps can installed by adding `alembic[tz]` to the pip requirements
 # string value is passed to ZoneInfo()
 # leave blank for localtime

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -17,7 +17,7 @@ prepend_sys_path = .
 
 # timezone to use when rendering the date within the migration file
 # as well as the filename.
-# If specified, requires the python>=3.9 or backports.zoneinfo library.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
 # Any required deps can installed by adding `alembic[tz]` to the pip requirements
 # string value is passed to ZoneInfo()
 # leave blank for localtime

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -141,7 +141,7 @@ The file generated with the "generic" configuration looks like::
 
     # timezone to use when rendering the date within the migration file
     # as well as the filename.
-    # If specified, requires the python>=3.9 or backports.zoneinfo library.
+    # If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
     # Any required deps can installed by adding `alembic[tz]` to the pip requirements
     # string value is passed to ZoneInfo()
     # leave blank for localtime
@@ -299,9 +299,9 @@ This file contains the following features:
 * ``timezone`` - an optional timezone name (e.g. ``UTC``, ``EST5EDT``, etc.)
   that will be applied to the timestamp which renders inside the migration
   file's comment as well as within the filename. This option requires Python>=3.9
-  or installing the ``backports.zoneinfo`` library. If ``timezone`` is specified,
-  the create date object is no longer derived from ``datetime.datetime.now()``
-  and is instead generated as::
+  or installing the ``backports.zoneinfo`` library and the ``tzdata`` library. 
+  If ``timezone`` is specified, the create date object is no longer derived
+  from ``datetime.datetime.now()`` and is instead generated as::
 
       datetime.datetime.utcnow().replace(
         tzinfo=datetime.timezone.utc

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
 [options.extras_require]
 tz =
     backports.zoneinfo;python_version<"3.9"
+    tzdata
 
 [options.package_data]
 alembic = *.pyi, py.typed


### PR DESCRIPTION
Add `tzdata` to `tz` extras, since `zoneinfo` on its own does not contain any timezones.

### Description
Fixes #1556 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed ✅
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted. ✅
	- Please include: `Fixes: #<issue number>` in the commit message ✅
	- please include tests.   one line code fixes without tests will not be accepted. ✅
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Additional info:
- `tzdata` was already included for tests: [link](https://github.com/sqlalchemy/alembic/blob/bd50ba325b10a1a9cdb452fe40c96f959825797c/tox.ini#L27)
- there are already tests for tz: [link](https://github.com/sqlalchemy/alembic/blob/bd50ba325b10a1a9cdb452fe40c96f959825797c/tests/test_script_production.py#L245-L307)

- I also tested all the available `tzdata` versions, and all of them were good:
```
Version `2024.2`: 597 timezones
Version `2024.1`: 597 timezones
Version `2023.1`: 597 timezones
Version `2022.1`: 595 timezones
Version `2021.1`: 594 timezones
Version `2020.1`: 594 timezones
Version `2020.1rc1`: 594 timezones
Version `2020.1rc0`: 594 timezones
Version `1.2016.8`: 421 timezones (annulled version)
Version `1.2016.7`: 421 timezones (annulled version)
Version `1.2016.6`: 421 timezones
Version `1.2016.5a1`: 421 timezones (annulled version)
```

- Also, there's already non-pinned version in [`tox.ini`](https://github.com/sqlalchemy/alembic/blob/bd50ba325b10a1a9cdb452fe40c96f959825797c/tox.ini#L27), so I think just `tzdata` should be good

- And I also installed my fix via `pip install git+https://github.com/Danipulok/alembic.git@fix/add-tzdata#egg=alembic[tz]` and everything worked