### PR TITLE
Initial work to support Starrocks DB

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -540,7 +540,7 @@ class MigrationContext:
                 return ()
         assert self.connection is not None
         return tuple(
-            row[0] for row in self.connection.execute(self._version.select())
+            row[0] for row in self.connection.execute(self._version.select().with_only_columns(self._version.c.version_num))
         )
 
     def _ensure_version_table(self, purge: bool = False) -> None:


### PR DESCRIPTION
I want to use Alembic with Starrocks database.

To achieve this I need to patch `alembic_version` table with following code

```
def patch_alembic_version(context, **kwargs):
    migration_context = context._proxy._migration_context
    old_version = migration_context._version
    metadata = old_version.metadata
    metadata.remove(old_version)

    version = Table(
        'alembic_version',
        metadata,
        Column('id', types.BIGINT, autoincrement=True, primary_key=True),
        Column('version_num', types.VARCHAR(32), primary_key=False),
        starrocks_primary_key="id"
    )
    migration_context._version = version
 ```

This solution works with one exception - select on alembic_version always read version_num from first column.

### Description
Fixes: https://github.com/sqlalchemy/alembic/issues/1560

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
