### PR TITLE
Avoid D103 linter warnings via script.py.mako

### DIFF
--- a/alembic/templates/async/script.py.mako
+++ b/alembic/templates/async/script.py.mako
@@ -19,8 +19,10 @@ depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
 
 
 def upgrade() -> None:
+    """Upgrade schema."""
     ${upgrades if upgrades else "pass"}
 
 
 def downgrade() -> None:
+    """Downgrade schema."""
     ${downgrades if downgrades else "pass"}

--- a/alembic/templates/generic/script.py.mako
+++ b/alembic/templates/generic/script.py.mako
@@ -19,8 +19,10 @@ depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
 
 
 def upgrade() -> None:
+    """Upgrade schema."""
     ${upgrades if upgrades else "pass"}
 
 
 def downgrade() -> None:
+    """Downgrade schema."""
     ${downgrades if downgrades else "pass"}

--- a/alembic/templates/multidb/script.py.mako
+++ b/alembic/templates/multidb/script.py.mako
@@ -22,10 +22,12 @@ depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
 
 
 def upgrade(engine_name: str) -> None:
+    """Upgrade schema."""
     globals()["upgrade_%s" % engine_name]()
 
 
 def downgrade(engine_name: str) -> None:
+    """Downgrade schema."""
     globals()["downgrade_%s" % engine_name]()
 
 <%
@@ -38,10 +40,12 @@ def downgrade(engine_name: str) -> None:
 % for db_name in re.split(r',\s*', db_names):
 
 def upgrade_${db_name}() -> None:
+    """Upgrade ${db_name} schema."""
     ${context.get("%s_upgrades" % db_name, "pass")}
 
 
 def downgrade_${db_name}() -> None:
+    """Downgrade ${db_name} schema."""
     ${context.get("%s_downgrades" % db_name, "pass")}
 
 % endfor


### PR DESCRIPTION
Closes #1567

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

This will silence the commonly used pydocstyle D103 warnings from flake8 or ruff check:

* http://www.pydocstyle.org/en/stable/error_codes.html#grouping
* https://docs.astral.sh/ruff/rules/undocumented-public-function/

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
