### PR TITLE
fix: Add TextClause to alter_column's server_default fields.

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -152,7 +152,7 @@ def alter_column(
     type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
     existing_type: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
     existing_server_default: Union[
-        str, bool, Identity, Computed, None
+        str, bool, Identity, Computed, TextClause, None
     ] = False,
     existing_nullable: Optional[bool] = None,
     existing_comment: Optional[str] = None,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Given sqlalchemy models with server_defaults, alembic may autogenerate `existing_server_default=sa.text("...")`, which fails typechecking on the resultant migration because `TextClause` is not currently a valid annotated type.

I'm just not sure whether there's a more general type that would make more sense or not. just that given what alembic itself is generating, this should presumably be allowed.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
