### PR TITLE
Docs: fix layout issue in autogenerate

### DIFF
--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -730,8 +730,8 @@ hook runner:
 The following configuration option is specific to the ``"exec"`` hook runner:
 
 * ``executable`` - the name of the executable to invoke.  Can be either a
-bare executable name which will be searched in ``$PATH``, or a full pathname
-to avoid potential issues with path interception.
+  bare executable name which will be searched in ``$PATH``, or a full pathname
+  to avoid potential issues with path interception.
 
 The following options are supported by both ``"console_scripts"`` and ``"exec"``:
 


### PR DESCRIPTION
### Description

During building of the docs, I got this warning:

> alembic/docs/build/autogenerate.rst:733: WARNING: Bullet list ends without a blank line; unexpected unindent. [docutils]

This also causes a small display issue, where the continuation of the line of the bullet point gets rendered as a new paragraph. This PR fixes the issue.

![Screenshot from 2025-01-06 17-39-16](https://github.com/user-attachments/assets/c2f252e5-752b-48b3-81a6-1fa854baafdd)


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
