### PR TITLE
Refactor `CommandLine` command registration

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -478,10 +478,15 @@ class CommandLine:
             ),
         ),
     }
-    _POSITIONAL_HELP = {
-        "directory": "location of scripts directory",
-        "revision": "revision identifier",
-        "revisions": "one or more revisions, or 'heads' for all heads",
+    _POSITIONAL_OPTS = {
+        "directory": dict(help="location of scripts directory"),
+        "revision": dict(
+            help="revision identifier",
+        ),
+        "revisions": dict(
+            nargs="+",
+            help="one or more revisions, or 'heads' for all heads",
+        ),
     }
     _POSITIONAL_TRANSLATIONS: dict[Any, dict[str, str]] = {
         command.stamp: {"revision": "revisions"}
@@ -552,24 +557,13 @@ class CommandLine:
         for arg in kwarg:
             if arg in self._KWARGS_OPTS:
                 kwarg_opt = self._KWARGS_OPTS[arg]
-                args, kw = kwarg_opt[0:-1], kwarg_opt[-1]
-                subparser.add_argument(*args, **kw)  # type:ignore
+                args, opts = kwarg_opt[0:-1], kwarg_opt[-1]
+                subparser.add_argument(*args, **opts)  # type:ignore
 
         for arg in positional:
-            if (
-                arg == "revisions"
-                or fn in self._POSITIONAL_TRANSLATIONS
-                and self._POSITIONAL_TRANSLATIONS[fn][arg] == "revisions"
-            ):
-                subparser.add_argument(
-                    "revisions",
-                    nargs="+",
-                    help=self._POSITIONAL_HELP.get("revisions"),
-                )
-            else:
-                subparser.add_argument(
-                    arg, help=self._POSITIONAL_HELP.get(arg)
-                )
+            if arg in self._POSITIONAL_OPTS:
+                opts = self._POSITIONAL_OPTS[arg]
+                subparser.add_argument(arg, **opts)  # type:ignore
 
     def _inspect_function(self, fn: Any) -> tuple[Any, Any, str]:
         spec = compat.inspect_getfullargspec(fn)

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -348,172 +348,144 @@ class CommandLine:
     def __init__(self, prog: Optional[str] = None) -> None:
         self._generate_args(prog)
 
+    _KWARGS_OPTS = {
+        "template": (
+            "-t",
+            "--template",
+            dict(
+                default="generic",
+                type=str,
+                help="Setup template for use with 'init'",
+            ),
+        ),
+        "message": (
+            "-m",
+            "--message",
+            dict(type=str, help="Message string to use with 'revision'"),
+        ),
+        "sql": (
+            "--sql",
+            dict(
+                action="store_true",
+                help="Don't emit SQL to database - dump to "
+                "standard output/file instead. See docs on "
+                "offline mode.",
+            ),
+        ),
+        "tag": (
+            "--tag",
+            dict(
+                type=str,
+                help="Arbitrary 'tag' name - can be used by custom env.py scripts.",
+            ),
+        ),
+        "head": (
+            "--head",
+            dict(
+                type=str,
+                help="Specify head revision or <branchname>@head "
+                "to base new revision on.",
+            ),
+        ),
+        "splice": (
+            "--splice",
+            dict(
+                action="store_true",
+                help="Allow a non-head revision as the 'head' to splice onto",
+            ),
+        ),
+        "depends_on": (
+            "--depends-on",
+            dict(
+                action="append",
+                help="Specify one or more revision identifiers "
+                "which this revision should depend on.",
+            ),
+        ),
+        "rev_id": (
+            "--rev-id",
+            dict(
+                type=str,
+                help="Specify a hardcoded revision id instead of generating one",
+            ),
+        ),
+        "version_path": (
+            "--version-path",
+            dict(
+                type=str,
+                help="Specify specific path from config for version file",
+            ),
+        ),
+        "branch_label": (
+            "--branch-label",
+            dict(
+                type=str,
+                help="Specify a branch label to apply to the new revision",
+            ),
+        ),
+        "verbose": (
+            "-v",
+            "--verbose",
+            dict(action="store_true", help="Use more verbose output"),
+        ),
+        "resolve_dependencies": (
+            "--resolve-dependencies",
+            dict(
+                action="store_true",
+                help="Treat dependency versions as down revisions",
+            ),
+        ),
+        "autogenerate": (
+            "--autogenerate",
+            dict(
+                action="store_true",
+                help="Populate revision script with candidate "
+                "migration operations, based on comparison "
+                "of database to model.",
+            ),
+        ),
+        "rev_range": (
+            "-r",
+            "--rev-range",
+            dict(
+                action="store",
+                help="Specify a revision range; format is [start]:[end]",
+            ),
+        ),
+        "indicate_current": (
+            "-i",
+            "--indicate-current",
+            dict(
+                action="store_true",
+                help="Indicate the current revision",
+            ),
+        ),
+        "purge": (
+            "--purge",
+            dict(
+                action="store_true",
+                help="Unconditionally erase the version table before stamping",
+            ),
+        ),
+        "package": (
+            "--package",
+            dict(
+                action="store_true",
+                help="Write empty __init__.py files to the "
+                "environment and version locations",
+            ),
+        ),
+    }
+    _POSITIONAL_HELP = {
+        "directory": "location of scripts directory",
+        "revision": "revision identifier",
+        "revisions": "one or more revisions, or 'heads' for all heads",
+    }
+    _POSITIONAL_TRANSLATIONS: dict[str, str] = {
+        command.stamp: {"revision": "revisions"}
+    }
+
     def _generate_args(self, prog: Optional[str]) -> None:
-        def add_options(
-            fn: Any, parser: Any, positional: Any, kwargs: Any
-        ) -> None:
-            kwargs_opts = {
-                "template": (
-                    "-t",
-                    "--template",
-                    dict(
-                        default="generic",
-                        type=str,
-                        help="Setup template for use with 'init'",
-                    ),
-                ),
-                "message": (
-                    "-m",
-                    "--message",
-                    dict(
-                        type=str, help="Message string to use with 'revision'"
-                    ),
-                ),
-                "sql": (
-                    "--sql",
-                    dict(
-                        action="store_true",
-                        help="Don't emit SQL to database - dump to "
-                        "standard output/file instead. See docs on "
-                        "offline mode.",
-                    ),
-                ),
-                "tag": (
-                    "--tag",
-                    dict(
-                        type=str,
-                        help="Arbitrary 'tag' name - can be used by "
-                        "custom env.py scripts.",
-                    ),
-                ),
-                "head": (
-                    "--head",
-                    dict(
-                        type=str,
-                        help="Specify head revision or <branchname>@head "
-                        "to base new revision on.",
-                    ),
-                ),
-                "splice": (
-                    "--splice",
-                    dict(
-                        action="store_true",
-                        help="Allow a non-head revision as the "
-                        "'head' to splice onto",
-                    ),
-                ),
-                "depends_on": (
-                    "--depends-on",
-                    dict(
-                        action="append",
-                        help="Specify one or more revision identifiers "
-                        "which this revision should depend on.",
-                    ),
-                ),
-                "rev_id": (
-                    "--rev-id",
-                    dict(
-                        type=str,
-                        help="Specify a hardcoded revision id instead of "
-                        "generating one",
-                    ),
-                ),
-                "version_path": (
-                    "--version-path",
-                    dict(
-                        type=str,
-                        help="Specify specific path from config for "
-                        "version file",
-                    ),
-                ),
-                "branch_label": (
-                    "--branch-label",
-                    dict(
-                        type=str,
-                        help="Specify a branch label to apply to the "
-                        "new revision",
-                    ),
-                ),
-                "verbose": (
-                    "-v",
-                    "--verbose",
-                    dict(action="store_true", help="Use more verbose output"),
-                ),
-                "resolve_dependencies": (
-                    "--resolve-dependencies",
-                    dict(
-                        action="store_true",
-                        help="Treat dependency versions as down revisions",
-                    ),
-                ),
-                "autogenerate": (
-                    "--autogenerate",
-                    dict(
-                        action="store_true",
-                        help="Populate revision script with candidate "
-                        "migration operations, based on comparison "
-                        "of database to model.",
-                    ),
-                ),
-                "rev_range": (
-                    "-r",
-                    "--rev-range",
-                    dict(
-                        action="store",
-                        help="Specify a revision range; "
-                        "format is [start]:[end]",
-                    ),
-                ),
-                "indicate_current": (
-                    "-i",
-                    "--indicate-current",
-                    dict(
-                        action="store_true",
-                        help="Indicate the current revision",
-                    ),
-                ),
-                "purge": (
-                    "--purge",
-                    dict(
-                        action="store_true",
-                        help="Unconditionally erase the version table "
-                        "before stamping",
-                    ),
-                ),
-                "package": (
-                    "--package",
-                    dict(
-                        action="store_true",
-                        help="Write empty __init__.py files to the "
-                        "environment and version locations",
-                    ),
-                ),
-            }
-            positional_help = {
-                "directory": "location of scripts directory",
-                "revision": "revision identifier",
-                "revisions": "one or more revisions, or 'heads' for all heads",
-            }
-            for arg in kwargs:
-                if arg in kwargs_opts:
-                    args = kwargs_opts[arg]
-                    args, kw = args[0:-1], args[-1]
-                    parser.add_argument(*args, **kw)
-
-            for arg in positional:
-                if (
-                    arg == "revisions"
-                    or fn in positional_translations
-                    and positional_translations[fn][arg] == "revisions"
-                ):
-                    subparser.add_argument(
-                        "revisions",
-                        nargs="+",
-                        help=positional_help.get("revisions"),
-                    )
-                else:
-                    subparser.add_argument(arg, help=positional_help.get(arg))
-
         parser = ArgumentParser(prog=prog)
 
         parser.add_argument(
@@ -532,7 +504,7 @@ class CommandLine:
             "--name",
             type=str,
             default="alembic",
-            help="Name of section in .ini file to " "use for Alembic config",
+            help="Name of section in .ini file to use for Alembic config",
         )
         parser.add_argument(
             "-x",
@@ -552,49 +524,78 @@ class CommandLine:
             action="store_true",
             help="Do not log to std output.",
         )
-        subparsers = parser.add_subparsers()
 
-        positional_translations: Dict[Any, Any] = {
-            command.stamp: {"revision": "revisions"}
-        }
-
-        for fn in [getattr(command, n) for n in dir(command)]:
+        self.subparsers = parser.add_subparsers()
+        alembic_commands = (
+            fn
+            for fn in (getattr(command, name) for name in dir(command))
             if (
                 inspect.isfunction(fn)
                 and fn.__name__[0] != "_"
                 and fn.__module__ == "alembic.command"
-            ):
-                spec = compat.inspect_getfullargspec(fn)
-                if spec[3] is not None:
-                    positional = spec[0][1 : -len(spec[3])]
-                    kwarg = spec[0][-len(spec[3]) :]
-                else:
-                    positional = spec[0][1:]
-                    kwarg = []
+            )
+        )
 
-                if fn in positional_translations:
-                    positional = [
-                        positional_translations[fn].get(name, name)
-                        for name in positional
-                    ]
+        for fn in alembic_commands:
+            self._register_command(fn)
 
-                # parse first line(s) of helptext without a line break
-                help_ = fn.__doc__
-                if help_:
-                    help_text = []
-                    for line in help_.split("\n"):
-                        if not line.strip():
-                            break
-                        else:
-                            help_text.append(line.strip())
-                else:
-                    help_text = []
-                subparser = subparsers.add_parser(
-                    fn.__name__, help=" ".join(help_text)
-                )
-                add_options(fn, subparser, positional, kwarg)
-                subparser.set_defaults(cmd=(fn, positional, kwarg))
         self.parser = parser
+
+    def _register_command(self, fn: Any) -> None:
+        fn, positional, kwarg, help_text = self._parse_command_from_function(fn)
+
+        subparser = self.subparsers.add_parser(fn.__name__, help=help_text)
+        subparser.set_defaults(cmd=(fn, positional, kwarg))
+
+        for arg in kwarg:
+            if arg in self._KWARGS_OPTS:
+                args = self._KWARGS_OPTS[arg]
+                args, kw = args[0:-1], args[-1]
+                subparser.add_argument(*args, **kw)
+
+        for arg in positional:
+            if (
+                arg == "revisions"
+                or fn in self._POSITIONAL_TRANSLATIONS
+                and self._POSITIONAL_TRANSLATIONS[fn][arg] == "revisions"
+            ):
+                subparser.add_argument(
+                    "revisions",
+                    nargs="+",
+                    help=self._POSITIONAL_HELP.get("revisions"),
+                )
+            else:
+                subparser.add_argument(arg, help=self._POSITIONAL_HELP.get(arg))
+
+    def _parse_command_from_function(self, fn: Any) -> tuple[Any, Any, Any, str]:
+        spec = compat.inspect_getfullargspec(fn)
+        if spec[3] is not None:
+            positional = spec[0][1 : -len(spec[3])]
+            kwarg = spec[0][-len(spec[3]) :]
+        else:
+            positional = spec[0][1:]
+            kwarg = []
+
+        if fn in self._POSITIONAL_TRANSLATIONS:
+            positional = [
+                self._POSITIONAL_TRANSLATIONS[fn].get(name, name) for name in positional
+            ]
+
+        # parse first line(s) of helptext without a line break
+        help_ = fn.__doc__
+        if help_:
+            help_lines = []
+            for line in help_.split("\n"):
+                if not line.strip():
+                    break
+                else:
+                    help_lines.append(line.strip())
+        else:
+            help_lines = []
+
+        help_text = " ".join(help_lines)
+
+        return fn, positional, kwarg, help_text
 
     def run_cmd(self, config: Config, options: Namespace) -> None:
         fn, positional, kwarg = options.cmd

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -376,7 +376,8 @@ class CommandLine:
             "--tag",
             dict(
                 type=str,
-                help="Arbitrary 'tag' name - can be used by custom env.py scripts.",
+                help="Arbitrary 'tag' name - can be used by "
+                "custom env.py scripts.",
             ),
         ),
         "head": (
@@ -406,7 +407,8 @@ class CommandLine:
             "--rev-id",
             dict(
                 type=str,
-                help="Specify a hardcoded revision id instead of generating one",
+                help="Specify a hardcoded revision id instead of "
+                "generating one",
             ),
         ),
         "version_path": (
@@ -542,7 +544,7 @@ class CommandLine:
         self.parser = parser
 
     def _register_command(self, fn: Any) -> None:
-        fn, positional, kwarg, help_text = self._parse_command_from_function(fn)
+        positional, kwarg, help_text = self._inspect_function(fn)
 
         subparser = self.subparsers.add_parser(fn.__name__, help=help_text)
         subparser.set_defaults(cmd=(fn, positional, kwarg))
@@ -565,9 +567,11 @@ class CommandLine:
                     help=self._POSITIONAL_HELP.get("revisions"),
                 )
             else:
-                subparser.add_argument(arg, help=self._POSITIONAL_HELP.get(arg))
+                subparser.add_argument(
+                    arg, help=self._POSITIONAL_HELP.get(arg)
+                )
 
-    def _parse_command_from_function(self, fn: Any) -> tuple[Any, Any, Any, str]:
+    def _inspect_function(self, fn: Any) -> tuple[Any, Any, str]:
         spec = compat.inspect_getfullargspec(fn)
         if spec[3] is not None:
             positional = spec[0][1 : -len(spec[3])]
@@ -578,7 +582,8 @@ class CommandLine:
 
         if fn in self._POSITIONAL_TRANSLATIONS:
             positional = [
-                self._POSITIONAL_TRANSLATIONS[fn].get(name, name) for name in positional
+                self._POSITIONAL_TRANSLATIONS[fn].get(name, name)
+                for name in positional
             ]
 
         # parse first line(s) of helptext without a line break
@@ -595,7 +600,7 @@ class CommandLine:
 
         help_text = " ".join(help_lines)
 
-        return fn, positional, kwarg, help_text
+        return positional, kwarg, help_text
 
     def run_cmd(self, config: Config, options: Namespace) -> None:
         fn, positional, kwarg = options.cmd

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -346,8 +346,9 @@ class MessagingOptions(TypedDict, total=False):
 
 
 class CommandFunction(Protocol):
-    """A function that may be registered in the CLI as an alembic command. It must be a
-    named function and it must accept a :class:`.Config` object as the first argument.
+    """A function that may be registered in the CLI as an alembic command.
+    It must be a named function and it must accept a :class:`.Config` object
+    as the first argument.
     """
 
     __name__: str
@@ -563,8 +564,8 @@ class CommandLine:
 
     def register_command(self, fn: CommandFunction) -> None:
         """Registers a function as a CLI subcommand. The subcommand name
-        matches the function name, the arguments are extracted from the signature
-        and the help text is read from the docstring.
+        matches the function name, the arguments are extracted from the
+        signature and the help text is read from the docstring.
 
         .. seealso::
 

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -584,9 +584,8 @@ class CommandLine:
                 subparser.add_argument(*args, **opts)  # type:ignore
 
         for arg in positional:
-            if arg in self._POSITIONAL_OPTS:
-                opts = self._POSITIONAL_OPTS[arg]
-                subparser.add_argument(arg, **opts)  # type:ignore
+            opts = self._POSITIONAL_OPTS.get(arg, {})
+            subparser.add_argument(arg, **opts)  # type:ignore
 
     def _inspect_function(self, fn: CommandFunction) -> tuple[Any, Any, str]:
         spec = compat.inspect_getfullargspec(fn)

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -481,7 +481,7 @@ class CommandLine:
         "revision": "revision identifier",
         "revisions": "one or more revisions, or 'heads' for all heads",
     }
-    _POSITIONAL_TRANSLATIONS: dict[str, str] = {
+    _POSITIONAL_TRANSLATIONS: dict[Any, dict[str, str]] = {
         command.stamp: {"revision": "revisions"}
     }
 
@@ -549,9 +549,9 @@ class CommandLine:
 
         for arg in kwarg:
             if arg in self._KWARGS_OPTS:
-                args = self._KWARGS_OPTS[arg]
-                args, kw = args[0:-1], args[-1]
-                subparser.add_argument(*args, **kw)
+                kwarg_opt = self._KWARGS_OPTS[arg]
+                args, kw = kwarg_opt[0:-1], kwarg_opt[-1]
+                subparser.add_argument(*args, **kw)  # type:ignore
 
         for arg in positional:
             if (

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -7,8 +7,8 @@ import io
 import os
 import sys
 import typing
-from typing import cast
 from typing import Any
+from typing import cast
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -56,9 +56,9 @@ else:
 def importlib_metadata_get(group: str) -> Sequence[EntryPoint]:
     ep = importlib_metadata.entry_points()
     if hasattr(ep, "select"):
-        return cast(Sequence[EntryPoint], ep.select(group=group))
+        return ep.select(group=group)
     else:
-        return ep.get(group, ())
+        return ep.get(group, ())  # type: ignore
 
 
 def formatannotation_fwdref(

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -8,7 +8,6 @@ import os
 import sys
 import typing
 from typing import Any
-from typing import cast
 from typing import List
 from typing import Optional
 from typing import Sequence

--- a/alembic/util/compat.py
+++ b/alembic/util/compat.py
@@ -7,6 +7,7 @@ import io
 import os
 import sys
 import typing
+from typing import cast
 from typing import Any
 from typing import List
 from typing import Optional
@@ -55,9 +56,9 @@ else:
 def importlib_metadata_get(group: str) -> Sequence[EntryPoint]:
     ep = importlib_metadata.entry_points()
     if hasattr(ep, "select"):
-        return ep.select(group=group)
+        return cast(Sequence[EntryPoint], ep.select(group=group))
     else:
-        return ep.get(group, ())  # type: ignore
+        return ep.get(group, ())
 
 
 def formatannotation_fwdref(

--- a/docs/build/cookbook.rst
+++ b/docs/build/cookbook.rst
@@ -1615,3 +1615,61 @@ The application maintains a version of schema with both versions.
 Writes are performed on both places, while the background script move all the remaining data across.
 This technique is very challenging and time demanding, since it requires custom application logic to
 handle the intermediate states.
+
+.. _custom_commandline:
+
+Extend ``CommandLine`` with custom commands
+===========================================
+
+While Alembic does not have a plugin system that would allow transparently extending the original ``alembic`` CLI
+with additional commands, it is possible to create your own instance of :class:`.CommandLine` and extend that via
+:meth:`.CommandLine.register_command`.
+
+.. code-block:: python
+
+    # myalembic.py
+
+    from alembic.config import CommandLine, Config
+
+
+    def frobnicate(config: Config, revision: str) -> None:
+        """Frobnicates according to the frobnication specification.
+
+        :param config: a :class:`.Config` instance
+        :param revision: the revision to frobnicate
+        """
+
+        config.print_stdout(f"Revision {revision} successfully frobnicated.")
+
+
+    def main():
+        cli = CommandLine()
+        cli.register_command(frobnicate)
+        cli.main()
+
+    if __name__ == "__main__":
+        main()
+
+Any named function may be registered as a command, provided it accepts a :class:`.Config` object as the first argument;
+a docstring is also recommended as it will show up in the help output of the CLI.
+
+.. code-block::
+
+    $ python -m myalembic -h
+    ...
+    positional arguments:
+      {branches,check,current,downgrade,edit,ensure_version,heads,history,init,list_templates,merge,revision,show,stamp,upgrade,frobnicate}
+        ...
+        frobnicate          Frobnicates according to the frobnication specification.
+
+    $ python -m myalembic frobnicate -h
+    usage: myalembic.py frobnicate [-h] revision
+
+    positional arguments:
+    revision    revision identifier
+
+    optional arguments:
+    -h, --help  show this help message and exit
+
+    $ python -m myalembic frobnicate 42
+    Revision 42 successfully frobnicated.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,3 +256,31 @@ class TemplateOutputEncodingTest(TestBase):
         self.cfg.set_main_option("output_encoding", "latin-1")
         script = ScriptDirectory.from_config(self.cfg)
         eq_(script.output_encoding, "latin-1")
+
+
+class CommandLineTest(TestBase):
+    def test_register_command(self):
+        cli = config.CommandLine()
+
+        fake_stdout = []
+            
+        def frobnicate(config: config.Config, revision: str) -> None:
+            """Frobnicates the revision.
+
+            :param config: a :class:`.Config` instance
+            :param revision: the revision to frobnicate
+            """
+
+            fake_stdout.append(f"Revision {revision} frobnicated.")
+
+        cli.register_command(frobnicate)
+
+        help_text = cli.parser.format_help()
+        assert frobnicate.__name__ in help_text
+        assert frobnicate.__doc__.split("\n")[0] in help_text
+
+        cli.main(["frobnicate", "abc42"])
+
+        assert fake_stdout == [
+            f"Revision abc42 frobnicated."
+        ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -263,7 +263,7 @@ class CommandLineTest(TestBase):
         cli = config.CommandLine()
 
         fake_stdout = []
-            
+
         def frobnicate(config: config.Config, revision: str) -> None:
             """Frobnicates the revision.
 
@@ -281,6 +281,4 @@ class CommandLineTest(TestBase):
 
         cli.main(["frobnicate", "abc42"])
 
-        assert fake_stdout == [
-            f"Revision abc42 frobnicated."
-        ]
+        assert fake_stdout == ["Revision abc42 frobnicated."]


### PR DESCRIPTION
Fixes: #1610

Refactors `CommandLine` internals so that it's easier to plug custom commands into the cli, in addition to the builtins `alembic.command`.
No public interface changes whatsoever. 

The topic was somewhat discussed here https://github.com/sqlalchemy/alembic/discussions/1456

### Description

The point from the linked discussion still applies - this does not enable any kind of plugin system, one would still need to have their own subclass of `CommandLine` and call it from their own script. However, the implementation of such a subclass should be much cleaner now. I would expect it to look like so:
```py
def frobnicate(config: Config, revision: str) -> None:
    """Frobnicates according to the frobnication specification.

    :param config: a :class:`.Config` instance
    :param revision: the revision to frobnicate
    """

    config.print_stdout(f"Revision {revision} successfully frobnicated.")


class MyCommandLine(CommandLine):
    def _generate_args(self, prog: str | None) -> None:
        super()._generate_args(prog)

        self._register_command(frobnicate)


if __name__ == "__main__":
    MyCommandLine().main()
```
```shell
❯ python cli.py frobnicate 42
Revision 42 successfully frobnicated.
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

 This is purely internal refactoring, so no new tests are required. For extra confidence I:
   - ran tests with `tox` locally;
   - compared the text of `alembic --help` before and after this change and made sure there was no diff. 

**Have a nice day!**
