### PR TITLE
fix AlterColumnOp modify_name ignorance

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -505,6 +505,7 @@ def _alter_column(
     type_ = op.modify_type
     nullable = op.modify_nullable
     comment = op.modify_comment
+    newname = op.modify_name
     autoincrement = op.kw.get("autoincrement", None)
     existing_type = op.existing_type
     existing_nullable = op.existing_nullable
@@ -533,6 +534,8 @@ def _alter_column(
         rendered = _render_server_default(server_default, autogen_context)
         text += ",\n%sserver_default=%s" % (indent, rendered)
 
+    if newname is not None:
+        text += ",\n%snew_column_name=%r" % (indent, newname)
     if type_ is not None:
         text += ",\n%stype_=%s" % (indent, _repr_type(type_, autogen_context))
     if nullable is not None:

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -1327,6 +1327,18 @@ class AutogenRenderTest(TestBase):
             {"from mypackage import MySpecialType"},
         )
 
+    def test_render_modify_name(self):
+        op_obj = ops.AlterColumnOp(
+            "sometable",
+            "somecolumn",
+            modify_name="newcolumnname",
+        )
+        eq_ignore_whitespace(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            "op.alter_column('sometable', 'somecolumn', "
+            "new_column_name='newcolumnname')",
+        )
+
     def test_render_modify_type(self):
         op_obj = ops.AlterColumnOp(
             "sometable",


### PR DESCRIPTION
fixes https://github.com/sqlalchemy/alembic/issues/1635
as the result of discussion https://github.com/sqlalchemy/alembic/discussions/1632#discussioncomment-12630711

### Description
added the lost processing of AlterColumnOp.modify_name

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
