### PR TITLE
fix `server_default` type hint

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -146,7 +146,9 @@ def alter_column(
     *,
     nullable: Optional[bool] = None,
     comment: Union[str, Literal[False], None] = False,
-    server_default: Union[str, bool, Identity, Computed, TextClause] = False,
+    server_default: Union[
+        str, bool, Identity, Computed, TextClause, None
+    ] = False,
     new_column_name: Optional[str] = None,
     type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
     existing_type: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -706,7 +706,7 @@ class Operations(AbstractOperations):
             nullable: Optional[bool] = None,
             comment: Union[str, Literal[False], None] = False,
             server_default: Union[
-                str, bool, Identity, Computed, TextClause
+                str, bool, Identity, Computed, TextClause, None
             ] = False,
             new_column_name: Optional[str] = None,
             type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -1841,7 +1841,7 @@ class AlterColumnOp(AlterTableOp):
         nullable: Optional[bool] = None,
         comment: Optional[Union[str, Literal[False]]] = False,
         server_default: Union[
-            str, bool, Identity, Computed, TextClause
+            str, bool, Identity, Computed, TextClause, None
         ] = False,
         new_column_name: Optional[str] = None,
         type_: Optional[Union[TypeEngine[Any], Type[TypeEngine[Any]]]] = None,


### PR DESCRIPTION
### Description

The docstring of `alter_column` states: "Set to `None` to have the default removed". The type hint should accept None.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Fixes: #1639