### PR TITLE
Fix more type hint of server_default

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -257,7 +257,9 @@ class DefaultImpl(metaclass=ImplMeta):
         table_name: str,
         column_name: str,
         nullable: Optional[bool] = None,
-        server_default: Union[_ServerDefault, Literal[False]] = False,
+        server_default: Optional[
+            Union[_ServerDefault, Literal[False]]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         schema: Optional[str] = None,

--- a/alembic/ddl/mysql.py
+++ b/alembic/ddl/mysql.py
@@ -52,7 +52,9 @@ class MySQLImpl(DefaultImpl):
         table_name: str,
         column_name: str,
         nullable: Optional[bool] = None,
-        server_default: Union[_ServerDefault, Literal[False]] = False,
+        server_default: Optional[
+            Union[_ServerDefault, Literal[False]]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         schema: Optional[str] = None,
@@ -174,7 +176,7 @@ class MySQLImpl(DefaultImpl):
     def _is_mysql_allowed_functional_default(
         self,
         type_: Optional[TypeEngine],
-        server_default: Union[_ServerDefault, Literal[False]],
+        server_default: Optional[Union[_ServerDefault, Literal[False]]],
     ) -> bool:
         return (
             type_ is not None
@@ -325,7 +327,7 @@ class MySQLAlterDefault(AlterColumn):
         self,
         name: str,
         column_name: str,
-        default: _ServerDefault,
+        default: Optional[_ServerDefault],
         schema: Optional[str] = None,
     ) -> None:
         super(AlterColumn, self).__init__(name, schema=schema)

--- a/alembic/ddl/postgresql.py
+++ b/alembic/ddl/postgresql.py
@@ -153,7 +153,9 @@ class PostgresqlImpl(DefaultImpl):
         table_name: str,
         column_name: str,
         nullable: Optional[bool] = None,
-        server_default: Union[_ServerDefault, Literal[False]] = False,
+        server_default: Optional[
+            Union[_ServerDefault, Literal[False]]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         schema: Optional[str] = None,


### PR DESCRIPTION
Follow-up commit db12e1918556dd463847db9ffb3e761231df9b1d (which is probably sufficient for type checking) by making all annotations of server_default consistent.