### PR TITLE
Add basic support for Starrocks

### DIFF
--- a/alembic/ddl/mysql.py
+++ b/alembic/ddl/mysql.py
@@ -321,6 +321,8 @@ class MySQLImpl(DefaultImpl):
 class MariaDBImpl(MySQLImpl):
     __dialect__ = "mariadb"
 
+class StarrocksImpl(MySQLImpl):
+    __dialect__ = "starrocks"
 
 class MySQLAlterDefault(AlterColumn):
     def __init__(


### PR DESCRIPTION
### Description
Starrocks is an analytical database (https://www.starrocks.io). It has its own dialect defined in sqlalchemy. Currently, alembic does not support this dialect. Starrocks implements MySQL protocol and many BI tools are recommended to use MySQL driver/connector to use Starrocks. This commit PR just subclasses MySQL driver to enable basic Starrocks support.