### PR TITLE
Support DROP CONSTRAINT IF EXISTS

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -387,8 +387,8 @@ class DefaultImpl(metaclass=ImplMeta):
         if const._create_rule is None or const._create_rule(self):
             self._exec(schema.AddConstraint(const))
 
-    def drop_constraint(self, const: Constraint) -> None:
-        self._exec(schema.DropConstraint(const))
+    def drop_constraint(self, const: Constraint, **kw: Any) -> None:
+        self._exec(schema.DropConstraint(const, **kw))
 
     def rename_table(
         self,

--- a/alembic/ddl/mysql.py
+++ b/alembic/ddl/mysql.py
@@ -167,6 +167,7 @@ class MySQLImpl(DefaultImpl):
     def drop_constraint(
         self,
         const: Constraint,
+        **kw: Any,
     ) -> None:
         if isinstance(const, schema.CheckConstraint) and _is_type_bound(const):
             return

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -91,7 +91,7 @@ class SQLiteImpl(DefaultImpl):
                 "SQLite migrations using a copy-and-move strategy."
             )
 
-    def drop_constraint(self, const: Constraint):
+    def drop_constraint(self, const: Constraint, **kw: Any):
         if const._create_rule is None:
             raise NotImplementedError(
                 "No support for ALTER of constraints in SQLite dialect. "

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -957,6 +957,7 @@ def drop_constraint(
     type_: Optional[str] = None,
     *,
     schema: Optional[str] = None,
+    if_exists: Optional[bool] = None,
 ) -> None:
     r"""Drop a constraint of the given name, typically via DROP CONSTRAINT.
 
@@ -968,6 +969,10 @@ def drop_constraint(
      quoting of the schema outside of the default behavior, use
      the SQLAlchemy construct
      :class:`~sqlalchemy.sql.elements.quoted_name`.
+    :param if_exists: If True, adds IF EXISTS operator when
+     dropping the constraint
+
+     .. versionadded:: 1.15.4
 
     """
 

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -1393,6 +1393,7 @@ class Operations(AbstractOperations):
             type_: Optional[str] = None,
             *,
             schema: Optional[str] = None,
+            if_exists: Optional[bool] = None,
         ) -> None:
             r"""Drop a constraint of the given name, typically via DROP CONSTRAINT.
 
@@ -1404,6 +1405,10 @@ class Operations(AbstractOperations):
              quoting of the schema outside of the default behavior, use
              the SQLAlchemy construct
              :class:`~sqlalchemy.sql.elements.quoted_name`.
+            :param if_exists: If True, adds IF EXISTS operator when
+             dropping the constraint
+
+             .. versionadded:: 1.15.4
 
             """  # noqa: E501
             ...

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -140,12 +140,14 @@ class DropConstraintOp(MigrateOperation):
         type_: Optional[str] = None,
         *,
         schema: Optional[str] = None,
+        if_exists: Optional[bool] = None,
         _reverse: Optional[AddConstraintOp] = None,
     ) -> None:
         self.constraint_name = constraint_name
         self.table_name = table_name
         self.constraint_type = type_
         self.schema = schema
+        self.if_exists = if_exists
         self._reverse = _reverse
 
     def reverse(self) -> AddConstraintOp:
@@ -203,6 +205,7 @@ class DropConstraintOp(MigrateOperation):
         type_: Optional[str] = None,
         *,
         schema: Optional[str] = None,
+        if_exists: Optional[bool] = None,
     ) -> None:
         r"""Drop a constraint of the given name, typically via DROP CONSTRAINT.
 
@@ -214,10 +217,14 @@ class DropConstraintOp(MigrateOperation):
          quoting of the schema outside of the default behavior, use
          the SQLAlchemy construct
          :class:`~sqlalchemy.sql.elements.quoted_name`.
+        :param if_exists: If True, adds IF EXISTS operator when
+         dropping the constraint
+
+         .. versionadded:: 1.15.4
 
         """
 
-        op = cls(constraint_name, table_name, type_=type_, schema=schema)
+        op = cls(constraint_name, table_name, type_=type_, schema=schema, if_exists=if_exists)
         return operations.invoke(op)
 
     @classmethod

--- a/alembic/operations/toimpl.py
+++ b/alembic/operations/toimpl.py
@@ -7,7 +7,7 @@ from sqlalchemy import schema as sa_schema
 
 from . import ops
 from .base import Operations
-from ..util.sqla_compat import _copy
+from ..util.sqla_compat import _copy, sqla_2
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.schema import Table
@@ -199,6 +199,8 @@ def drop_constraint(
 ) -> None:
     kw = {}
     if operation.if_exists is not None:
+        if not sqla_2:
+            raise NotImplementedError("SQLAlchemy 2.0 required")
         kw["if_exists"] = operation.if_exists
     operations.impl.drop_constraint(
         operations.schema_obj.generic_constraint(

--- a/alembic/operations/toimpl.py
+++ b/alembic/operations/toimpl.py
@@ -197,13 +197,17 @@ def create_constraint(
 def drop_constraint(
     operations: "Operations", operation: "ops.DropConstraintOp"
 ) -> None:
+    kw = {}
+    if operation.if_exists is not None:
+        kw["if_exists"] = operation.if_exists
     operations.impl.drop_constraint(
         operations.schema_obj.generic_constraint(
             operation.constraint_name,
             operation.table_name,
             operation.constraint_type,
             schema=operation.schema,
-        )
+        ),
+        **kw
     )
 
 

--- a/docs/build/unreleased/1650.rst
+++ b/docs/build/unreleased/1650.rst
@@ -1,0 +1,5 @@
+.. change::
+    :tags: usecase, operations
+    :tickets: 1650
+
+    Support if_exists on drop constraint operations

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -823,8 +823,14 @@ class OpTest(TestBase):
 
     def test_drop_constraint_if_exists(self):
         context = op_fixture()
-        op.drop_constraint("foo_bar_bat", "t1", if_exists=True)
-        context.assert_("ALTER TABLE t1 DROP CONSTRAINT IF EXISTS foo_bar_bat")
+        if sqla_compat.sqla_2:
+            op.drop_constraint("foo_bar_bat", "t1", if_exists=True)
+            context.assert_("ALTER TABLE t1 DROP CONSTRAINT IF EXISTS foo_bar_bat")
+        else:
+            with expect_raises_message(
+                NotImplementedError, "SQLAlchemy 2.0 required"
+            ):
+                op.drop_constraint("foo_bar_bat", "t1", if_exists=True)
 
     def test_create_index(self):
         context = op_fixture()

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -821,6 +821,11 @@ class OpTest(TestBase):
         op.drop_constraint("foo_bar_bat", "t1", schema="foo")
         context.assert_("ALTER TABLE foo.t1 DROP CONSTRAINT foo_bar_bat")
 
+    def test_drop_constraint_if_exists(self):
+        context = op_fixture()
+        op.drop_constraint("foo_bar_bat", "t1", if_exists=True)
+        context.assert_("ALTER TABLE t1 DROP CONSTRAINT IF EXISTS foo_bar_bat")
+
     def test_create_index(self):
         context = op_fixture()
         op.create_index("ik_test", "t1", ["foo", "bar"])


### PR DESCRIPTION
Fixes #1650

### Description
Adds support for the `IF EXISTS` clause on `DROP CONSTRAINT` operations

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
