### PR TITLE
ExecuteSQLOp rendering respects alembic_module_prefix

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -1122,7 +1122,10 @@ def _execute_sql(autogen_context: AutogenContext, op: ops.ExecuteSQLOp) -> str:
             "Autogenerate rendering of SQL Expression language constructs "
             "not supported here; please use a plain SQL string"
         )
-    return "op.execute(%r)" % op.sqltext
+    return "{prefix}execute({sqltext!r})".format(
+        prefix=_alembic_autogenerate_prefix(autogen_context),
+        sqltext=op.sqltext,
+    )
 
 
 renderers = default_renderers.branch()

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -2035,9 +2035,17 @@ class AutogenRenderTest(TestBase):
             op_obj,
         )
 
-    @testing.combinations(("test.",), (None,), argnames="alembic_module_prefix")
-    def test_render_executesql_alembic_module_prefix(self, alembic_module_prefix):
-        self.autogen_context.opts.update(alembic_module_prefix=alembic_module_prefix)
+    @testing.combinations(
+        ("test.",), (None,),
+        argnames="alembic_module_prefix",
+    )
+    def test_render_executesql_alembic_module_prefix(
+        self,
+        alembic_module_prefix,
+    ):
+        self.autogen_context.opts.update(
+            alembic_module_prefix=alembic_module_prefix
+        )
         op_obj = ops.ExecuteSQLOp("drop table foo")
         eq_(
             autogenerate.render_op_text(self.autogen_context, op_obj),

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -2035,6 +2035,15 @@ class AutogenRenderTest(TestBase):
             op_obj,
         )
 
+    @testing.combinations(("test.",), (None,), argnames="alembic_module_prefix")
+    def test_render_executesql_alembic_module_prefix(self, alembic_module_prefix):
+        self.autogen_context.opts.update(alembic_module_prefix=alembic_module_prefix)
+        op_obj = ops.ExecuteSQLOp("drop table foo")
+        eq_(
+            autogenerate.render_op_text(self.autogen_context, op_obj),
+            f"{alembic_module_prefix or ''}execute('drop table foo')",
+        )
+
     def test_render_alter_column_modify_comment(self):
         op_obj = ops.AlterColumnOp(
             "sometable", "somecolumn", modify_comment="This is a comment"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Rendering ExecuteSQLOp did not respect the `alembic_module_prefix` setting due
to having `op.` hard-coded in its template.

This change updates the render logic to use the same
`_alembic_autogenerate_prefix()` as it seems the rest of the ops use.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


Fixes #1656
