### PR TITLE
fix(typings): improve typing for server_default

### DIFF
--- a/alembic/ddl/base.py
+++ b/alembic/ddl/base.py
@@ -29,14 +29,14 @@ if TYPE_CHECKING:
     from sqlalchemy import Identity
     from sqlalchemy.sql.compiler import Compiled
     from sqlalchemy.sql.compiler import DDLCompiler
+    from sqlalchemy.sql.elements import ColumnElement
     from sqlalchemy.sql.elements import TextClause
-    from sqlalchemy.sql.functions import Function
     from sqlalchemy.sql.schema import FetchedValue
     from sqlalchemy.sql.type_api import TypeEngine
 
     from .impl import DefaultImpl
 
-_ServerDefault = Union["TextClause", "FetchedValue", "Function[Any]", str]
+_ServerDefault = Union["FetchedValue", str, "TextClause", "ColumnElement[Any]"]
 
 
 class AlterTable(DDLElement):

--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.expression import TableClause
     from sqlalchemy.sql.schema import Column
     from sqlalchemy.sql.schema import Computed
+    from sqlalchemy.sql.schema import FetchedValue
     from sqlalchemy.sql.schema import Identity
     from sqlalchemy.sql.schema import SchemaItem
     from sqlalchemy.sql.schema import Table
@@ -154,15 +155,11 @@ def alter_column(
     *,
     nullable: Optional[bool] = None,
     comment: Union[str, Literal[False], None] = False,
-    server_default: Union[
-        str, bool, Identity, Computed, TextClause, None
-    ] = False,
+    server_default: Union["FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]] = False,
     new_column_name: Optional[str] = None,
     type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
     existing_type: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
-    existing_server_default: Union[
-        str, bool, Identity, Computed, TextClause, None
-    ] = False,
+    existing_server_default: Optional[Union["FetchedValue", str, "TextClause", "ColumnElement[Any]"]] = None,
     existing_nullable: Optional[bool] = None,
     existing_comment: Optional[str] = None,
     schema: Optional[str] = None,

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.expression import TextClause
     from sqlalchemy.sql.schema import Column
     from sqlalchemy.sql.schema import Computed
+    from sqlalchemy.sql.schema import FetchedValue
     from sqlalchemy.sql.schema import Identity
     from sqlalchemy.sql.schema import SchemaItem
     from sqlalchemy.types import TypeEngine
@@ -711,16 +712,16 @@ class Operations(AbstractOperations):
             nullable: Optional[bool] = None,
             comment: Union[str, Literal[False], None] = False,
             server_default: Union[
-                str, bool, Identity, Computed, TextClause, None
+                "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
             ] = False,
             new_column_name: Optional[str] = None,
             type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
             existing_type: Union[
                 TypeEngine[Any], Type[TypeEngine[Any]], None
             ] = None,
-            existing_server_default: Union[
-                str, bool, Identity, Computed, TextClause, None
-            ] = False,
+            existing_server_default: Optional[Union[
+                "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
+            ]] = None,
             existing_nullable: Optional[bool] = None,
             existing_comment: Optional[str] = None,
             schema: Optional[str] = None,
@@ -1678,15 +1679,17 @@ class BatchOperations(AbstractOperations):
             *,
             nullable: Optional[bool] = None,
             comment: Union[str, Literal[False], None] = False,
-            server_default: Any = False,
+            server_default: Union[
+                "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
+            ] = False,
             new_column_name: Optional[str] = None,
             type_: Union[TypeEngine[Any], Type[TypeEngine[Any]], None] = None,
             existing_type: Union[
                 TypeEngine[Any], Type[TypeEngine[Any]], None
             ] = None,
-            existing_server_default: Union[
-                str, bool, Identity, Computed, None
-            ] = False,
+            existing_server_default: Optional[Union[
+                "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
+            ]] = None,
             existing_nullable: Optional[bool] = None,
             existing_comment: Optional[str] = None,
             insert_before: Optional[str] = None,

--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -43,9 +43,11 @@ if TYPE_CHECKING:
 
     from sqlalchemy.engine import Dialect
     from sqlalchemy.sql.elements import ColumnClause
+    from sqlalchemy.sql.elements import ColumnElement
+    from sqlalchemy.sql.elements import TextClause
     from sqlalchemy.sql.elements import quoted_name
-    from sqlalchemy.sql.functions import Function
     from sqlalchemy.sql.schema import Constraint
+    from sqlalchemy.sql.schema import FetchedValue
     from sqlalchemy.sql.type_api import TypeEngine
 
     from ..ddl.impl import DefaultImpl
@@ -485,7 +487,9 @@ class ApplyBatchImpl:
         table_name: str,
         column_name: str,
         nullable: Optional[bool] = None,
-        server_default: Optional[Union[Function[Any], str, bool]] = False,
+        server_default: Union[
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         autoincrement: Optional[Union[bool, Literal["auto"]]] = None,

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql.schema import Constraint
     from sqlalchemy.sql.schema import ForeignKeyConstraint
     from sqlalchemy.sql.schema import Identity
+    from sqlalchemy.sql.schema import FetchedValue
     from sqlalchemy.sql.schema import Index
     from sqlalchemy.sql.schema import MetaData
     from sqlalchemy.sql.schema import PrimaryKeyConstraint
@@ -1696,7 +1697,9 @@ class AlterColumnOp(AlterTableOp):
         *,
         schema: Optional[str] = None,
         existing_type: Optional[Any] = None,
-        existing_server_default: Any = False,
+        existing_server_default: Optional[Union[
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]"
+        ]] = None,
         existing_nullable: Optional[bool] = None,
         existing_comment: Optional[str] = None,
         modify_nullable: Optional[bool] = None,
@@ -1856,16 +1859,16 @@ class AlterColumnOp(AlterTableOp):
         nullable: Optional[bool] = None,
         comment: Optional[Union[str, Literal[False]]] = False,
         server_default: Union[
-            str, bool, Identity, Computed, TextClause, None
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
         ] = False,
         new_column_name: Optional[str] = None,
         type_: Optional[Union[TypeEngine[Any], Type[TypeEngine[Any]]]] = None,
         existing_type: Optional[
             Union[TypeEngine[Any], Type[TypeEngine[Any]]]
         ] = None,
-        existing_server_default: Union[
-            str, bool, Identity, Computed, TextClause, None
-        ] = False,
+        existing_server_default: Optional[Union[
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]"
+        ]] = None,
         existing_nullable: Optional[bool] = None,
         existing_comment: Optional[str] = None,
         schema: Optional[str] = None,
@@ -1980,15 +1983,17 @@ class AlterColumnOp(AlterTableOp):
         *,
         nullable: Optional[bool] = None,
         comment: Optional[Union[str, Literal[False]]] = False,
-        server_default: Any = False,
+        server_default: Union[
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]", None, Literal[False]
+        ] = False,
         new_column_name: Optional[str] = None,
         type_: Optional[Union[TypeEngine[Any], Type[TypeEngine[Any]]]] = None,
         existing_type: Optional[
             Union[TypeEngine[Any], Type[TypeEngine[Any]]]
         ] = None,
-        existing_server_default: Optional[
-            Union[str, bool, Identity, Computed]
-        ] = False,
+        existing_server_default: Optional[Union[
+            "FetchedValue", str, "TextClause", "ColumnElement[Any]"
+        ]] = None,
         existing_nullable: Optional[bool] = None,
         existing_comment: Optional[str] = None,
         insert_before: Optional[str] = None,


### PR DESCRIPTION
### Description
Issue #1669 shows that the typings for server default were inconsistent with sqlaclhemy's definition.

In this PR we:
- fix the definition of `_ServerDefault` to match that of sqlalchemy's `_ServerDefaultArgument`
- use that same definition in all places that use a `server_default` or `existing_server_default`

Note that the last change also changes the default of the argument `existing_server_default` from `False` to `None`. This could be a breaking change, however that argument is currently typed in manyplaces as `Optional[_ServerDefault] = None` (and `_ServerDefault` does not include `bool`).

Fixes #1669

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
