### PR TITLE
pass `context.config.config_args` to `logging.config.fileConfig`

### DIFF
--- a/alembic/templates/async/env.py
+++ b/alembic/templates/async/env.py
@@ -14,7 +14,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, defaults=config.config_args)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/alembic/templates/generic/env.py
+++ b/alembic/templates/generic/env.py
@@ -12,7 +12,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, defaults=config.config_args)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/alembic/templates/multidb/env.py
+++ b/alembic/templates/multidb/env.py
@@ -16,7 +16,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, defaults=config.config_args)
 logger = logging.getLogger("alembic.env")
 
 # gather section names referring to different

--- a/alembic/templates/pyproject/env.py
+++ b/alembic/templates/pyproject/env.py
@@ -12,7 +12,7 @@ config = context.config
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, defaults=config.config_args)
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
Some projects, like Pyramid, support `%(here)s` interpolation in `.ini` files for logging.

Extending Alembic to support this is trivial.  The data is already computed as part of `config.config_args`.  The `env.py` files just need to pass in these args as `defaults`:

-     fileConfig(config.config_file_name)
+     fileConfig(config.config_file_name, defaults=config.config_args)
