### PR TITLE
fix: remove double quotation marks in logs

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -683,7 +683,7 @@ def _compare_indexes_and_uniques(
             ):
                 modify_ops.ops.append(ops.CreateIndexOp.from_index(obj.const))
                 log.info(
-                    "Detected added index '%r' on '%s'",
+                    "Detected added index %r on '%s'",
                     obj.name,
                     obj.column_names,
                 )


### PR DESCRIPTION


<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/6f85a2e5-5551-455e-ae8c-95200d139655" />


- the '%r' caused two single ticks like '' to show
- What we want is a single tick '
- This aligns now with the usage in other log statements

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
