### PR TITLE
Fix pyproject.toml formatting when appending alembic config

### DIFF
--- a/tests/test_append_template.py
+++ b/tests/test_append_template.py
@@ -1,0 +1,41 @@
+"""Tests for pyproject.toml template functionality."""
+import os
+import tempfile
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.testing import TestBase
+
+
+class TestPyprojectTemplate(TestBase):
+    """Test the pyproject template, particularly issue #1679."""
+    
+    def test_init_pyproject_existing_file_formatting(self):
+        """Test that appending to existing pyproject.toml maintains proper spacing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chdir(tmpdir)
+            
+            # Create existing pyproject.toml
+            pyproject_path = Path("pyproject.toml")
+            pyproject_path.write_text(
+                '[tool.black]\ntarget-version = [\'py37\']\n\n'
+                '[tool.mypy]\npython_version = "3.10"'
+            )
+            
+            # Run init
+            config = Config("pyproject.toml")
+            command.init(config, "alembic", template="pyproject")
+            
+            # Check result
+            result = pyproject_path.read_text()
+            
+            # Verify no concatenation (issue #1679)
+            assert 'python_version = "3.10"[tool.alembic]' not in result
+            
+            # Verify proper spacing
+            assert '\n\n[tool.alembic]' in result
+            
+            # Verify content preserved
+            assert '[tool.black]' in result
+            assert '[tool.mypy]' in result


### PR DESCRIPTION
- Modified _append_template to ensure proper TOML section spacing
- Added special handling for .toml files to insert two newlines between sections
- Added tests to prevent regression
- Fixes #1679

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This PR fixes issue #1679 where `alembic init --template pyproject` would concatenate sections without proper spacing when appending to an existing `pyproject.toml` file.

**Problem**: The `[tool.alembic]` section was appended directly after the last line of the existing content, resulting in invalid TOML:
[tool.mypy]
python_version = "3.10"[tool.alembic]

**Solution**: Modified `_append_template` method in `ScriptDirectory` to detect TOML files and ensure proper spacing (2 newlines) between top-level sections.

**Result**: Proper TOML formatting is maintained:
```toml
[tool.mypy]
python_version = "3.10"

[tool.alembic]
script_location = "%(here)s/alembic"


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
