### PR TITLE
Add "module" post-write hook

### DIFF
--- a/alembic/script/write_hooks.py
+++ b/alembic/script/write_hooks.py
@@ -113,17 +113,35 @@ def _parse_cmdline_options(cmdline_options_str: str, path: str) -> List[str]:
     return cmdline_options_list
 
 
+def _get_required_option(options: dict, name: str) -> str:
+    try:
+        return options[name]
+    except KeyError as ke:
+        raise util.CommandError(
+            f"Key {options['_hook_name']}.{name} is required for post "
+            f"write hook {options['_hook_name']!r}"
+        ) from ke
+
+
+def _run_hook(
+    path: str, options: dict, ignore_output: bool, command: List[str]
+) -> None:
+    cwd: Optional[str] = options.get("cwd", None)
+    cmdline_options_str = options.get("options", "")
+    cmdline_options_list = _parse_cmdline_options(cmdline_options_str, path)
+
+    kw: Dict[str, Any] = {}
+    if ignore_output:
+        kw["stdout"] = kw["stderr"] = subprocess.DEVNULL
+
+    subprocess.run([*command, *cmdline_options_list], cwd=cwd, **kw)
+
+
 @register("console_scripts")
 def console_scripts(
     path: str, options: dict, ignore_output: bool = False
 ) -> None:
-    try:
-        entrypoint_name = options["entrypoint"]
-    except KeyError as ke:
-        raise util.CommandError(
-            f"Key {options['_hook_name']}.entrypoint is required for post "
-            f"write hook {options['_hook_name']!r}"
-        ) from ke
+    entrypoint_name = _get_required_option(options, "entrypoint")
     for entry in compat.importlib_metadata_get("console_scripts"):
         if entry.name == entrypoint_name:
             impl: Any = entry
@@ -132,81 +150,27 @@ def console_scripts(
         raise util.CommandError(
             f"Could not find entrypoint console_scripts.{entrypoint_name}"
         )
-    cwd: Optional[str] = options.get("cwd", None)
-    cmdline_options_str = options.get("options", "")
-    cmdline_options_list = _parse_cmdline_options(cmdline_options_str, path)
 
-    kw: Dict[str, Any] = {}
-    if ignore_output:
-        kw["stdout"] = kw["stderr"] = subprocess.DEVNULL
-
-    subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            f"import {impl.module}; {impl.module}.{impl.attr}()",
-        ]
-        + cmdline_options_list,
-        cwd=cwd,
-        **kw,
-    )
+    command = [
+        sys.executable,
+        "-c",
+        f"import {impl.module}; {impl.module}.{impl.attr}()",
+    ]
+    _run_hook(path, options, ignore_output, command)
 
 
 @register("exec")
 def exec_(path: str, options: dict, ignore_output: bool = False) -> None:
-    try:
-        executable = options["executable"]
-    except KeyError as ke:
-        raise util.CommandError(
-            f"Key {options['_hook_name']}.executable is required for post "
-            f"write hook {options['_hook_name']!r}"
-        ) from ke
-    cwd: Optional[str] = options.get("cwd", None)
-    cmdline_options_str = options.get("options", "")
-    cmdline_options_list = _parse_cmdline_options(cmdline_options_str, path)
-
-    kw: Dict[str, Any] = {}
-    if ignore_output:
-        kw["stdout"] = kw["stderr"] = subprocess.DEVNULL
-
-    subprocess.run(
-        [
-            executable,
-            *cmdline_options_list,
-        ],
-        cwd=cwd,
-        **kw,
-    )
+    executable = _get_required_option(options, "executable")
+    _run_hook(path, options, ignore_output, command=[executable])
 
 
 @register("module")
 def module(path: str, options: dict, ignore_output: bool = False) -> None:
-    try:
-        module_name = options["module"]
-    except KeyError as ke:
-        raise util.CommandError(
-            f"Key {options['_hook_name']}.module is required for post "
-            f"write hook {options['_hook_name']!r}"
-        ) from ke
+    module_name = _get_required_option(options, "module")
 
     if importlib.util.find_spec(module_name) is None:
         raise util.CommandError(f"Could not find module {module_name}")
 
-    cwd: Optional[str] = options.get("cwd", None)
-    cmdline_options_str = options.get("options", "")
-    cmdline_options_list = _parse_cmdline_options(cmdline_options_str, path)
-
-    kw: Dict[str, Any] = {}
-    if ignore_output:
-        kw["stdout"] = kw["stderr"] = subprocess.DEVNULL
-
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            module_name,
-        ]
-        + cmdline_options_list,
-        cwd=cwd,
-        **kw,
-    )
+    command = [sys.executable, "-m", module_name]
+    _run_hook(path, options, ignore_output, command)

--- a/alembic/templates/async/alembic.ini.mako
+++ b/alembic/templates/async/alembic.ini.mako
@@ -98,10 +98,16 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.executable = ruff
 # ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration.  This is also consumed by the user-maintained

--- a/alembic/templates/generic/alembic.ini.mako
+++ b/alembic/templates/generic/alembic.ini.mako
@@ -98,10 +98,16 @@ sqlalchemy.url = driver://user:pass@localhost/dbname
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.executable = ruff
 # ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration.  This is also consumed by the user-maintained

--- a/alembic/templates/multidb/alembic.ini.mako
+++ b/alembic/templates/multidb/alembic.ini.mako
@@ -106,10 +106,16 @@ sqlalchemy.url = driver://user:pass@localhost/dbname2
 # black.entrypoint = black
 # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-# lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
 # hooks = ruff
 # ruff.type = exec
-# ruff.executable = %(here)s/.venv/bin/ruff
+# ruff.executable = ruff
 # ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
 # Logging configuration.  This is also consumed by the user-maintained

--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -721,12 +721,16 @@ Above, we configure ``hooks`` to be a single post write hook labeled
 configuration for the ``"black"`` post write hook, which includes:
 
 * ``type`` - this is the type of hook we are running.  Alembic includes
-  two hook runners: ``"console_scripts"``, which is specifically a
-  Python function that uses ``subprocess.run()`` to invoke a separate
-  Python script against the revision file; and ``"exec"``, which uses
-  ``subprocess.run()`` to execute an arbitrary binary.  For a custom-written
-  hook function, this configuration variable would refer to the name under
-  which the custom hook was registered; see the next section for an example.
+  three hook runners:
+
+  * ``"console_scripts"``, which is specifically a Python function that uses
+    ``subprocess.run()`` to invoke a separate Python script against the revision file;
+  * ``"exec"``, which uses ``subprocess.run()`` to execute an arbitrary binary; and
+  * ``"module"``, which uses ``subprocess.run()`` to invoke a Python module directly.
+
+  For a custom-written hook function, this configuration variable would
+  refer to the name under which the custom hook was registered; see the
+  next section for an example.
 
 .. versionadded:: 1.12 added new ``exec`` runner
 

--- a/docs/build/tutorial.rst
+++ b/docs/build/tutorial.rst
@@ -248,10 +248,16 @@ The all-in-one .ini file created by ``generic`` is illustrated below::
     # black.entrypoint = black
     # black.options = -l 79 REVISION_SCRIPT_FILENAME
 
-    # lint with attempts to fix using "ruff" - use the exec runner, execute a binary
+    # lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+    # hooks = ruff
+    # ruff.type = module
+    # ruff.module = ruff
+    # ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+    # Alternatively, use the exec runner to execute a binary found on your PATH
     # hooks = ruff
     # ruff.type = exec
-    # ruff.executable = %(here)s/.venv/bin/ruff
+    # ruff.executable = ruff
     # ruff.options = check --fix REVISION_SCRIPT_FILENAME
 
     # Logging configuration.  This is also consumed by the user-maintained


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This hook type is almost identical to the console_scripts hook, except
it's running `python -m black` instead of using black's console_script.

It is mainly useful for tools without console scripts (e.g. ruff), but
has semantics closer to the console_scripts hook in that it finds the
ruff module available to the running interpreter instead of finding
an executable by path.

Fixes #1686

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
