### PR TITLE
Fixed missing prefix on FetchedValue

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -813,6 +813,8 @@ def _render_server_default(
             return _render_potential_expr(
                 default.arg, autogen_context, is_server_default=True
             )
+    elif isinstance(default, sa_schema.FetchedValue):
+        return _render_fetched_value(autogen_context)
 
     if isinstance(default, str) and repr_:
         default = repr(re.sub(r"^'|'$", "", default))
@@ -847,6 +849,12 @@ def _render_identity(
     return "%(prefix)sIdentity(%(kwargs)s)" % {
         "prefix": _sqlalchemy_autogenerate_prefix(autogen_context),
         "kwargs": (", ".join("%s=%s" % pair for pair in kwargs.items())),
+    }
+
+
+def _render_fetched_value(autogen_context: AutogenContext) -> str:
+    return "%(prefix)sFetchedValue()" % {
+        "prefix": _sqlalchemy_autogenerate_prefix(autogen_context),
     }
 
 

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -11,6 +11,7 @@ from sqlalchemy import DATETIME
 from sqlalchemy import DateTime
 from sqlalchemy import DefaultClause
 from sqlalchemy import Enum
+from sqlalchemy import FetchedValue
 from sqlalchemy import ForeignKey
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import func
@@ -2056,6 +2057,15 @@ class AutogenRenderTest(TestBase):
             result,
             "sa.Column('value', sa.Integer(), "
             "server_default='0', nullable=True)",
+        )
+
+    def test_render_server_default_fetched_value(self):
+        c = Column("value", Integer, server_default=FetchedValue())
+        result = autogenerate.render._render_column(c, self.autogen_context)
+        eq_(
+            result,
+            "sa.Column('value', sa.Integer(), "
+            "server_default=sa.FetchedValue(), nullable=True)",
         )
 
     def test_render_modify_reflected_int_server_default(self):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixed the rendering of `server_default=FetchedValue()` to ensure it is preceded by the `sa.` prefix in the migration script.
Refer to #1633

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
