### PR TITLE
Fixes https://github.com/sqlalchemy/alembic/issues/1719

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -963,8 +963,28 @@ def drop_column(
      it, at the moment.
     """
 
+@overload
 def drop_constraint(
     constraint_name: str,
+    table_name: str,
+    type_: Optional[str] = None,
+    *,
+    schema: Optional[str] = None,
+    if_exists: Optional[bool] = None,
+) -> None: ...
+
+@overload  
+def drop_constraint(
+    constraint_name: None,
+    table_name: str,
+    type_: str,
+    *,
+    schema: Optional[str] = None,
+    if_exists: Optional[bool] = None,
+) -> None: ...
+
+def drop_constraint(
+    constraint_name: Optional[str],
     table_name: str,
     type_: Optional[str] = None,
     *,

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -1397,7 +1397,7 @@ class Operations(AbstractOperations):
 
         def drop_constraint(
             self,
-            constraint_name: str,
+            constraint_name: Optional[str],
             table_name: str,
             type_: Optional[str] = None,
             *,

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -202,7 +202,7 @@ class DropConstraintOp(MigrateOperation):
     def drop_constraint(
         cls,
         operations: Operations,
-        constraint_name: str,
+        constraint_name: Optional[str],
         table_name: str,
         type_: Optional[str] = None,
         *,


### PR DESCRIPTION
my type checker has made me notice an inconsistency in the `drop_constraint` function


- `drop_constraint` declares `constraint_name: str` in both the type stubs (op.pyi) and implementation (operations/base.py)
- the underlying `DropConstraintOp` class accepts `Optional[str]` by `constraint_name_or_none()`.

### Description
Added
- optional string type for `constraint_name` in
  - type stubs file
  - `ops.py` 
  - `operations/base.py`
- added overload for None constrain names to accept types. I did this out of what I spotted on the test cases, [here](https://github.com/sqlalchemy/alembic/blob/6526dededd233913e67351750f8c5afe116ab039/tests/test_autogen_composition.py#L129) for instance. But i lack all details, so maybe this is in vain.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
