### PR TITLE
Add logging for config load source in verbose mode

### DIFF
--- a/alembic/config.py
+++ b/alembic/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from argparse import ArgumentParser
 from argparse import Namespace
 from configparser import ConfigParser
@@ -26,6 +27,9 @@ from . import command
 from . import util
 from .util import compat
 from .util.pyfiles import _preserving_path_as_str
+
+
+log = logging.getLogger(__name__)
 
 
 class Config:
@@ -244,10 +248,16 @@ class Config:
             here = Path()
         self.config_args["here"] = here.as_posix()
         file_config = ConfigParser(self.config_args)
+
+        verbose = getattr(self.cmd_opts, "verbose", False)
         if self._config_file_path:
             compat.read_config_parser(file_config, [self._config_file_path])
+            if verbose:
+                log.info("Loading config from file: %s", self._config_file_path)
         else:
             file_config.add_section(self.config_ini_section)
+            if verbose:
+                log.info("No config file provided; using in-memory default config")
         return file_config
 
     @util.memoized_property


### PR DESCRIPTION
### Description
This fixes: #1737

I added a log message to indicate where the Alembic configuration is being loaded from (file vs in-memory), which helps when verbose mode is enabled.

I also wrote tests for both branches. Each test passes when run individually, but they fail when running the entire test suite. It seems to be related to how Alembic’s logging hierarchy interacts with the global test environment, and I'm having difficulty diagnosing the issue with my current understanding of the logging system.

I'd appreciate any guidance or suggestions from maintainers on how the logging should be captured or how tests in this area are expected to be structured.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
