### PR TITLE
Add --splice support to merge command

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -385,6 +385,7 @@ def merge(
     message: Optional[str] = None,
     branch_label: Optional[_RevIdType] = None,
     rev_id: Optional[str] = None,
+    splice: bool = False,
 ) -> Optional[Script]:
     """Merge two revisions together.  Creates a new migration file.
 
@@ -435,6 +436,7 @@ def merge(
         refresh=True,
         head=revisions,
         branch_labels=branch_label,
+        splice=splice,
         **template_args,  # type:ignore[arg-type]
     )
 

--- a/alembic/config.py
+++ b/alembic/config.py
@@ -737,7 +737,7 @@ class CommandLine:
             "--splice",
             dict(
                 action="store_true",
-                help="Allow a non-head revision as the 'head' to splice onto",
+                help="Allow using a non-head revision as a base by disabling head-only validation",
             ),
         ),
         "depends_on": (


### PR DESCRIPTION
This fixes: #1712 

### Description
I noticed that no one was actively working on this issue, so I went ahead and implemented support for the --splice option in the merge command.

This change allows merge to operate with non-head revisions by disabling the head-only validation, consistent with the behavior of --splice in revision.

Key points included in this PR:
- Adds --splice support to alembic merge, allowing non-head revisions to be used as merge bases.
- Updates the help text to reflect the new behavior.
- Adds test coverage to validate both the failure case (splice=False) and the successful merge case (splice=True) using non-head revisions.

Let me know if further adjustments or additional tests would be helpful.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
