### PR TITLE
[Fixes #1761] Add opt-in autogenerate support for check constraints

### DIFF
--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -1466,9 +1466,15 @@ def _compare_check_constraints(
     }
 
     metadata_cks_by_name = {
-        c.name: c for c in metadata_cks_sig if c.name is not None
+        c.name: c
+        for c in metadata_cks_sig
+        if sqla_compat.constraint_name_string(c.name)
     }
-    conn_cks_by_name = {c.name: c for c in conn_cks_sig if c.name is not None}
+    conn_cks_by_name = {
+        c.name: c
+        for c in conn_cks_sig
+        if sqla_compat.constraint_name_string(c.name)
+    }
 
     def _add_ck(obj, compare_to):
         if autogen_context.run_object_filters(

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -1465,10 +1465,12 @@ def _compare_check_constraints(
         for ck in conn_check_constraints
     }
 
-    metadata_cks_by_name = {
+    metadata_cks_by_name: Dict[str, Any] = {
         c.name: c for c in metadata_cks_sig if c.name is not None
     }
-    conn_cks_by_name = {c.name: c for c in conn_cks_sig if c.name is not None}
+    conn_cks_by_name: Dict[str, Any] = {
+        c.name: c for c in conn_cks_sig if c.name is not None
+    }
 
     def _add_ck(obj, compare_to):
         if autogen_context.run_object_filters(

--- a/alembic/autogenerate/compare.py
+++ b/alembic/autogenerate/compare.py
@@ -1466,12 +1466,12 @@ def _compare_check_constraints(
     }
 
     metadata_cks_by_name = {
-        c.name: c
+        str(c.name): c
         for c in metadata_cks_sig
         if sqla_compat.constraint_name_string(c.name)
     }
     conn_cks_by_name = {
-        c.name: c
+        str(c.name): c
         for c in conn_cks_sig
         if sqla_compat.constraint_name_string(c.name)
     }
@@ -1507,8 +1507,8 @@ def _compare_check_constraints(
     ):
         const = conn_cks_by_name[removed_name]
         compare_to = (
-            metadata_cks_by_name[const.name].const
-            if const.name in metadata_cks_by_name
+            metadata_cks_by_name[removed_name].const
+            if removed_name in metadata_cks_by_name
             else None
         )
         _remove_ck(const, compare_to)
@@ -1518,8 +1518,8 @@ def _compare_check_constraints(
     ):
         const = metadata_cks_by_name[added_name]
         compare_to = (
-            conn_cks_by_name[const.name].const
-            if const.name in conn_cks_by_name
+            conn_cks_by_name[added_name].const
+            if added_name in conn_cks_by_name
             else None
         )
         _add_ck(const, compare_to)

--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -445,7 +445,9 @@ def _add_check_constraint(
     if not autogen_context._has_batch:
         args.append(repr(_ident(op.table_name)))
 
-    if hasattr(op.condition, "text"):
+    if isinstance(op.condition, str):
+        condition_text = op.condition
+    elif hasattr(op.condition, "text"):
         condition_text = op.condition.text
     else:
         from sqlalchemy.dialects import postgresql

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -113,6 +113,7 @@ def configure(
                     "index",
                     "unique_constraint",
                     "foreign_key_constraint",
+                    "check_constraint",
                 ],
                 MutableMapping[
                     Literal[
@@ -138,6 +139,7 @@ def configure(
                     "index",
                     "unique_constraint",
                     "foreign_key_constraint",
+                    "check_constraint",
                 ],
                 bool,
                 Optional[SchemaItem],
@@ -392,6 +394,20 @@ def configure(
 
         :paramref:`.EnvironmentContext.configure.compare_type`
 
+    :param compare_check_constraints: Indicates check constraint comparison
+     behavior during an autogenerate operation.  Defaults to ``False``
+     which disables check constraint comparison.  Set to ``True`` to
+     turn on check constraint comparison, which will detect added,
+     removed, and modified named check constraints.
+
+    This feature requires that check constraints have explicit names.
+    Unnamed check constraints will not be detected.
+
+    Check constraint comparison may produce false positives if the
+    database normalizes the SQL text differently from how it was
+    originally defined. This is an opt-in feature due to potential
+    compatibility issues across different database backends.
+
     :param include_name: A callable function which is given
      the chance to return ``True`` or ``False`` for any database reflected
      object based on its name, including database schema names when
@@ -405,7 +421,8 @@ def configure(
        database connection.
      * ``type``: a string describing the type of object; currently
        ``"schema"``, ``"table"``, ``"column"``, ``"index"``,
-       ``"unique_constraint"``, or ``"foreign_key_constraint"``
+       ``"unique_constraint"``, ``"foreign_key_constraint"``, or
+       ``"check_constraint"``
      * ``parent_names``: a dictionary of "parent" object names, that are
        relative to the name being given.  Keys in this dictionary may
        include:  ``"schema_name"``, ``"table_name"`` or
@@ -444,14 +461,15 @@ def configure(
      * ``object``: a :class:`~sqlalchemy.schema.SchemaItem` object such
        as a :class:`~sqlalchemy.schema.Table`,
        :class:`~sqlalchemy.schema.Column`,
-       :class:`~sqlalchemy.schema.Index`
+       :class:`~sqlalchemy.schema.Index`,
        :class:`~sqlalchemy.schema.UniqueConstraint`,
-       or :class:`~sqlalchemy.schema.ForeignKeyConstraint` object
+       :class:`~sqlalchemy.schema.ForeignKeyConstraint`, or
+       :class:`~sqlalchemy.schema.CheckConstraint` object
      * ``name``: the name of the object. This is typically available
        via ``object.name``.
      * ``type``: a string describing the type of object; currently
        ``"table"``, ``"column"``, ``"index"``, ``"unique_constraint"``,
-       or ``"foreign_key_constraint"``
+       ``"foreign_key_constraint"``, or ``"check_constraint"``
      * ``reflected``: ``True`` if the given object was produced based on
        table reflection, ``False`` if it's from a local :class:`.MetaData`
        object.
@@ -514,20 +532,6 @@ def configure(
         :paramref:`.EnvironmentContext.configure.include_name`
 
         :paramref:`.EnvironmentContext.configure.include_object`
-
-    :param compare_check_constraints: Indicates check constraint comparison
-     behavior during an autogenerate operation.  Defaults to ``False``
-     which disables check constraint comparison.  Set to ``True`` to
-     turn on check constraint comparison, which will detect added,
-     removed, and modified named check constraints.
-
-    This feature requires that check constraints have explicit names.
-    Unnamed check constraints will not be detected.
-
-    Check constraint comparison may produce false positives if the
-    database normalizes the SQL text differently from how it was
-    originally defined. This is an opt-in feature due to potential
-    compatibility issues across different database backends.
 
     :param render_item: Callable that can be used to override how
      any schema item, i.e. column, constraint, type,

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -183,6 +183,7 @@ def configure(
             Optional[bool],
         ],
     ] = False,
+    compare_check_constraints: bool = False,
     render_item: Optional[
         Callable[[str, Any, AutogenContext], Union[str, Literal[False]]]
     ] = None,
@@ -513,6 +514,20 @@ def configure(
         :paramref:`.EnvironmentContext.configure.include_name`
 
         :paramref:`.EnvironmentContext.configure.include_object`
+
+    :param compare_check_constraints: Indicates check constraint comparison
+     behavior during an autogenerate operation.  Defaults to ``False``
+     which disables check constraint comparison.  Set to ``True`` to
+     turn on check constraint comparison, which will detect added,
+     removed, and modified named check constraints.
+
+    This feature requires that check constraints have explicit names.
+    Unnamed check constraints will not be detected.
+
+    Check constraint comparison may produce false positives if the
+    database normalizes the SQL text differently from how it was
+    originally defined. This is an opt-in feature due to potential
+    compatibility issues across different database backends.
 
     :param render_item: Callable that can be used to override how
      any schema item, i.e. column, constraint, type,

--- a/alembic/context.pyi
+++ b/alembic/context.pyi
@@ -113,6 +113,7 @@ def configure(
                     "index",
                     "unique_constraint",
                     "foreign_key_constraint",
+                    "check_constraint",
                 ],
                 MutableMapping[
                     Literal[
@@ -138,6 +139,7 @@ def configure(
                     "index",
                     "unique_constraint",
                     "foreign_key_constraint",
+                    "check_constraint",
                 ],
                 bool,
                 Optional[SchemaItem],

--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from sqlalchemy.sql import ClauseElement
     from sqlalchemy.sql import Executable
     from sqlalchemy.sql.elements import quoted_name
+    from sqlalchemy.sql.schema import CheckConstraint
     from sqlalchemy.sql.schema import Constraint
     from sqlalchemy.sql.schema import ForeignKeyConstraint
     from sqlalchemy.sql.schema import Index
@@ -820,6 +821,13 @@ class DefaultImpl(metaclass=ImplMeta):
             )
         else:
             return ComparisonResult.Equal()
+
+    def compare_check_constraint(
+        self,
+        metadata_constraint: CheckConstraint,
+        reflected_constraint: CheckConstraint,
+    ) -> ComparisonResult:
+        return ComparisonResult.Equal()
 
     def _skip_functional_indexes(self, metadata_indexes, conn_indexes):
         conn_indexes_by_name = {c.name: c for c in conn_indexes}

--- a/alembic/testing/requirements.py
+++ b/alembic/testing/requirements.py
@@ -59,6 +59,10 @@ class SuiteRequirements(Requirements):
         return exclusions.open()
 
     @property
+    def check_constraint_reflection(self):
+        return exclusions.open()
+
+    @property
     def check_constraints_w_enforcement(self):
         """Target database must support check constraints
         and also enforce them."""

--- a/tests/test_autogen_check_constraints.py
+++ b/tests/test_autogen_check_constraints.py
@@ -1,0 +1,312 @@
+from sqlalchemy import CheckConstraint
+from sqlalchemy import Column
+from sqlalchemy import Enum
+from sqlalchemy import Integer
+from sqlalchemy import MetaData
+from sqlalchemy import String
+from sqlalchemy import Table
+
+from alembic.testing import assert_raises_message
+from alembic.testing import config
+from alembic.testing import eq_
+from alembic.testing import is_true
+from alembic.testing import TestBase
+from alembic.testing.suite._autogen_fixtures import AutogenFixtureTest
+
+
+class AutogenerateCheckConstraintsTest(AutogenFixtureTest, TestBase):
+    __backend__ = True
+    __only_on__ = "postgresql"
+
+    def test_add_check_constraint(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        eq_(len(diffs), 1)
+        eq_(diffs[0][0], "add_constraint")
+        eq_(diffs[0][1].name, "ck_value_positive")
+
+    def test_remove_check_constraint(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        eq_(len(diffs), 1)
+        eq_(diffs[0][0], "remove_constraint")
+        eq_(diffs[0][1].name, "ck_value_positive")
+
+    def test_no_change_when_constraint_matches(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        eq_(len(diffs), 0)
+
+    def test_no_diff_when_compare_check_constraints_false(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        diffs = self._fixture(
+            m1, m2, opts={"compare_check_constraints": False}
+        )
+
+        eq_(len(diffs), 0)
+
+    def test_unnamed_constraint_raises(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0"),
+        )
+
+        assert_raises_message(
+            ValueError,
+            r"Unnamed check constraint on table 'some_table' cannot be compared",
+            self._fixture,
+            m1,
+            m2,
+            opts={"compare_check_constraints": True},
+        )
+
+    def test_multiple_constraints(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            Column("status", String(20)),
+            CheckConstraint("value > 0", name="ck_value_positive"),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            Column("status", String(20)),
+            CheckConstraint("value >= 0", name="ck_value_non_negative"),
+            CheckConstraint("status IS NOT NULL", name="ck_status_not_null"),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        eq_(len(diffs), 3)
+
+        diff_types = {(d[0], d[1].name) for d in diffs}
+        eq_(
+            diff_types,
+            {
+                ("remove_constraint", "ck_value_positive"),
+                ("add_constraint", "ck_value_non_negative"),
+                ("add_constraint", "ck_status_not_null"),
+            },
+        )
+
+    def test_enum_type_bound_constraint_ignored(self):
+        import enum
+
+        class Status(enum.Enum):
+            ACTIVE = "active"
+            INACTIVE = "inactive"
+
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column(
+                "status",
+                Enum(Status, name="status_enum", create_constraint=True),
+            ),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column(
+                "status",
+                Enum(Status, name="status_enum", create_constraint=True),
+            ),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        enum_diffs = [
+            d
+            for d in diffs
+            if d[0] in ("add_constraint", "remove_constraint")
+            and isinstance(d[1], CheckConstraint)
+        ]
+        eq_(len(enum_diffs), 0)
+
+    def test_constraint_with_bound_parameter(self):
+        import sqlalchemy as sa
+
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("source", String(50)),
+        )
+
+        source_col = sa.column("source")
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("source", String(50)),
+            CheckConstraint(
+                source_col == "MANUAL",
+                name="ck_source_manual",
+            ),
+        )
+
+        diffs = self._fixture(m1, m2, opts={"compare_check_constraints": True})
+
+        eq_(len(diffs), 1)
+        eq_(diffs[0][0], "add_constraint")
+        eq_(diffs[0][1].name, "ck_source_manual")
+
+    def test_constraint_name_with_spaces_raises(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="invalid name with spaces"),
+        )
+
+        assert_raises_message(
+            ValueError,
+            r"Check constraint name 'invalid name with spaces' on table "
+            r"'some_table' contains invalid characters",
+            self._fixture,
+            m1,
+            m2,
+            opts={"compare_check_constraints": True},
+        )
+
+    def test_constraint_name_with_special_chars_raises(self):
+        m1 = MetaData()
+        m2 = MetaData()
+
+        Table(
+            "some_table",
+            m1,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+        )
+
+        Table(
+            "some_table",
+            m2,
+            Column("id", Integer, primary_key=True),
+            Column("value", Integer),
+            CheckConstraint("value > 0", name="invalid-name-with-dashes"),
+        )
+
+        assert_raises_message(
+            ValueError,
+            r"Check constraint name 'invalid-name-with-dashes' on table "
+            r"'some_table' contains invalid characters",
+            self._fixture,
+            m1,
+            m2,
+            opts={"compare_check_constraints": True},
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This adds an opt-in compare_check_constraints configuration option for autogenerate, allowing Alembic to detect check constraint differences between SQLAlchemy models and the database.

Changes:
* New config option compare_check_constraints
* Check constraint comparison logic
* Check constraint signature class
* Renderer for CreateCheckConstraintOp
* Comparison method
* Type stub
* Tests covering add, remove, match, disabled, unnamed, invalid names, enum filtering, and bound parameters

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
