### PR TITLE
Fix typo and grammar in autogenerate documentation

### DIFF
--- a/docs/build/autogenerate.rst
+++ b/docs/build/autogenerate.rst
@@ -188,11 +188,11 @@ Autogenerate can't currently, but **will eventually detect**:
   the supporting SQLAlchemy dialect.
 * Sequence additions, removals - not yet implemented.
 
-Notable 3-rd party libraries that extend the built-in Alembic autogenerate functionality
+Notable 3rd-party libraries that extend the built-in Alembic autogenerate functionality
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * `alembic-utils <https://github.com/olirice/alembic_utils>`_
-  A library that adds autogenerate support PostgreSQL functions, views, triggers, etc.
+  A library that adds autogenerate support for PostgreSQL functions, views, triggers, etc.
 * `alembic-postgresql-enum <https://pypi.org/project/alembic-postgresql-enum>`_
   A library that adds autogenerate support for creation, alteration and deletion of Enums in PostgreSQL.
 


### PR DESCRIPTION
### Description
I fixed a typo and the grammar within the "Notable 3-rd party libraries that extend the built-in Alembic autogenerate functionality" part of the "Auto Generating Migrations" section.

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
