### PR TITLE
Fix: SQLite STRICT is not propagated in batch mode (#1758)

### DIFF
--- a/alembic/ddl/impl.py
+++ b/alembic/ddl/impl.py
@@ -175,12 +175,16 @@ class DefaultImpl(metaclass=ImplMeta):
         )
         if version_table_pk:
             vt.append_constraint(
-                PrimaryKeyConstraint("version_num", name=f"{version_table}_pkc")
+                PrimaryKeyConstraint(
+                    "version_num", name=f"{version_table}_pkc"
+                )
             )
 
         return vt
 
-    def requires_recreate_in_batch(self, batch_op: BatchOperationsImpl) -> bool:
+    def requires_recreate_in_batch(
+        self, batch_op: BatchOperationsImpl
+    ) -> bool:
         """Return True if the given :class:`.BatchOperationsImpl`
         would need the table to be recreated and copied in order to
         proceed.
@@ -191,7 +195,9 @@ class DefaultImpl(metaclass=ImplMeta):
         """
         return False
 
-    def prep_table_for_batch(self, batch_impl: ApplyBatchImpl, table: Table) -> None:
+    def prep_table_for_batch(
+        self, batch_impl: ApplyBatchImpl, table: Table
+    ) -> None:
         """perform any operations needed on a table before a new
         one is created to replace it in batch mode.
 
@@ -218,7 +224,9 @@ class DefaultImpl(metaclass=ImplMeta):
                 raise TypeError("SQL parameters not allowed with as_sql")
 
             compile_kw: dict[str, Any]
-            if self.literal_binds and not isinstance(construct, schema.DDLElement):
+            if self.literal_binds and not isinstance(
+                construct, schema.DDLElement
+            ):
                 compile_kw = dict(compile_kwargs={"literal_binds": True})
             else:
                 compile_kw = {}
@@ -227,7 +235,8 @@ class DefaultImpl(metaclass=ImplMeta):
                 assert isinstance(construct, ClauseElement)
             compiled = construct.compile(dialect=self.dialect, **compile_kw)
             self.static_output(
-                str(compiled).replace("\t", "    ").strip() + self.command_terminator
+                str(compiled).replace("\t", "    ").strip()
+                + self.command_terminator
             )
             return None
         else:
@@ -237,7 +246,9 @@ class DefaultImpl(metaclass=ImplMeta):
                 conn = conn.execution_options(**execution_options)
 
             if params and multiparams is not None:
-                raise TypeError("Can't send params and multiparams at the same time")
+                raise TypeError(
+                    "Can't send params and multiparams at the same time"
+                )
 
             if multiparams:
                 return conn.execute(construct, multiparams)
@@ -257,7 +268,9 @@ class DefaultImpl(metaclass=ImplMeta):
         column_name: str,
         *,
         nullable: Optional[bool] = None,
-        server_default: Optional[Union[_ServerDefaultType, Literal[False]]] = False,
+        server_default: Optional[
+            Union[_ServerDefaultType, Literal[False]]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         schema: Optional[str] = None,
@@ -274,7 +287,8 @@ class DefaultImpl(metaclass=ImplMeta):
     ) -> None:
         if autoincrement is not None or existing_autoincrement is not None:
             util.warn(
-                "autoincrement and existing_autoincrement only make sense for MySQL",
+                "autoincrement and existing_autoincrement "
+                "only make sense for MySQL",
                 stacklevel=3,
             )
         if nullable is not None:
@@ -396,7 +410,9 @@ class DefaultImpl(metaclass=ImplMeta):
         **kw,
     ) -> None:
         self._exec(
-            base.DropColumn(table_name, column, schema=schema, if_exists=if_exists)
+            base.DropColumn(
+                table_name, column, schema=schema, if_exists=if_exists
+            )
         )
 
     def add_constraint(self, const: Any, **kw: Any) -> None:
@@ -415,7 +431,9 @@ class DefaultImpl(metaclass=ImplMeta):
         new_table_name: Union[str, quoted_name],
         schema: Optional[Union[str, quoted_name]] = None,
     ) -> None:
-        self._exec(base.RenameTable(old_table_name, new_table_name, schema=schema))
+        self._exec(
+            base.RenameTable(old_table_name, new_table_name, schema=schema)
+        )
 
     def create_table(self, table: Table, **kw: Any) -> None:
         table.dispatch.before_create(
@@ -485,7 +503,9 @@ class DefaultImpl(metaclass=ImplMeta):
                                 sqla_compat._literal_bindparam(
                                     k, v, type_=table.c[k].type
                                 )
-                                if not isinstance(v, sqla_compat._literal_bindparam)
+                                if not isinstance(
+                                    v, sqla_compat._literal_bindparam
+                                )
                                 else v
                             )
                             for k, v in row.items()
@@ -550,7 +570,9 @@ class DefaultImpl(metaclass=ImplMeta):
         inspector_all_terms = " ".join(
             [inspector_params.token0] + inspector_params.tokens
         )
-        metadata_all_terms = " ".join([metadata_params.token0] + metadata_params.tokens)
+        metadata_all_terms = " ".join(
+            [metadata_params.token0] + metadata_params.tokens
+        )
 
         for batch in synonyms:
             if {inspector_all_terms, metadata_all_terms}.issubset(batch) or {
@@ -560,7 +582,9 @@ class DefaultImpl(metaclass=ImplMeta):
                 return True
         return False
 
-    def _column_args_match(self, inspected_params: Params, meta_params: Params) -> bool:
+    def _column_args_match(
+        self, inspected_params: Params, meta_params: Params
+    ) -> bool:
         """We want to compare column parameters. However, we only want
         to compare parameters that are set. If they both have `collation`,
         we want to make sure they are the same. However, if only one
@@ -627,7 +651,9 @@ class DefaultImpl(metaclass=ImplMeta):
 
     def cast_for_batch_migrate(self, existing, existing_transfer, new_type):
         if existing.type._type_affinity is not new_type._type_affinity:
-            existing_transfer["expr"] = cast(existing_transfer["expr"], new_type)
+            existing_transfer["expr"] = cast(
+                existing_transfer["expr"], new_type
+            )
 
     def render_ddl_sql_expr(
         self, expr: ClauseElement, is_server_default: bool = False, **kw: Any
@@ -639,7 +665,9 @@ class DefaultImpl(metaclass=ImplMeta):
 
         compile_kw = {"literal_binds": True, "include_table": False}
 
-        return str(expr.compile(dialect=self.dialect, compile_kwargs=compile_kw))
+        return str(
+            expr.compile(dialect=self.dialect, compile_kwargs=compile_kw)
+        )
 
     def _compat_autogen_column_reflect(self, inspector: Inspector) -> Callable:
         return self.autogen_column_reflect
@@ -760,7 +788,9 @@ class DefaultImpl(metaclass=ImplMeta):
         This method returns a ``ComparisonResult``.
         """
         msg: List[str] = []
-        unique_msg = self._compare_index_unique(metadata_index, reflected_index)
+        unique_msg = self._compare_index_unique(
+            metadata_index, reflected_index
+        )
         if unique_msg:
             msg.append(unique_msg)
         m_sig = self._create_metadata_constraint_sig(metadata_index)
@@ -781,7 +811,9 @@ class DefaultImpl(metaclass=ImplMeta):
                 )
 
         if m_sig.column_names != r_sig.column_names:
-            msg.append(f"expression {r_sig.column_names} to {m_sig.column_names}")
+            msg.append(
+                f"expression {r_sig.column_names} to {m_sig.column_names}"
+            )
 
         if msg:
             return ComparisonResult.Different(msg)
@@ -800,13 +832,19 @@ class DefaultImpl(metaclass=ImplMeta):
 
         This method returns a ``ComparisonResult``.
         """
-        metadata_tup = self._create_metadata_constraint_sig(metadata_constraint)
-        reflected_tup = self._create_reflected_constraint_sig(reflected_constraint)
+        metadata_tup = self._create_metadata_constraint_sig(
+            metadata_constraint
+        )
+        reflected_tup = self._create_reflected_constraint_sig(
+            reflected_constraint
+        )
 
         meta_sig = metadata_tup.unnamed
         conn_sig = reflected_tup.unnamed
         if conn_sig != meta_sig:
-            return ComparisonResult.Different(f"expression {conn_sig} to {meta_sig}")
+            return ComparisonResult.Different(
+                f"expression {conn_sig} to {meta_sig}"
+            )
         else:
             return ComparisonResult.Equal()
 

--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -46,7 +46,9 @@ class SQLiteImpl(DefaultImpl):
     see: http://bugs.python.org/issue10740
     """
 
-    def requires_recreate_in_batch(self, batch_op: BatchOperationsImpl) -> bool:
+    def requires_recreate_in_batch(
+        self, batch_op: BatchOperationsImpl
+    ) -> bool:
         """Return True if the given :class:`.BatchOperationsImpl`
         would need the table to be recreated and copied in order to
         proceed.
@@ -58,9 +60,9 @@ class SQLiteImpl(DefaultImpl):
         for op in batch_op.batch:
             if op[0] == "add_column":
                 col = op[1][1]
-                if isinstance(col.server_default, schema.DefaultClause) and isinstance(
-                    col.server_default.arg, sql.ClauseElement
-                ):
+                if isinstance(
+                    col.server_default, schema.DefaultClause
+                ) and isinstance(col.server_default.arg, sql.ClauseElement):
                     return True
                 elif (
                     isinstance(col.server_default, Computed)
@@ -178,8 +180,9 @@ class SQLiteImpl(DefaultImpl):
             expr, is_server_default=is_server_default, **kw
         )
 
-        if is_server_default and self._guess_if_default_is_unparenthesized_sql_expr(
-            str_expr
+        if (
+            is_server_default
+            and self._guess_if_default_is_unparenthesized_sql_expr(str_expr)
         ):
             str_expr = "(%s)" % (str_expr,)
         return str_expr
@@ -194,7 +197,9 @@ class SQLiteImpl(DefaultImpl):
             existing.type._type_affinity is not new_type._type_affinity
             and not isinstance(new_type, JSON)
         ):
-            existing_transfer["expr"] = cast(existing_transfer["expr"], new_type)
+            existing_transfer["expr"] = cast(
+                existing_transfer["expr"], new_type
+            )
 
     def correct_for_autogen_constraints(
         self,
@@ -207,7 +212,9 @@ class SQLiteImpl(DefaultImpl):
 
 
 @compiles(RenameTable, "sqlite")
-def visit_rename_table(element: RenameTable, compiler: DDLCompiler, **kw) -> str:
+def visit_rename_table(
+    element: RenameTable, compiler: DDLCompiler, **kw
+) -> str:
     return "%s RENAME TO %s" % (
         alter_table(compiler, element.table_name, element.schema),
         format_table_name(compiler, element.new_table_name, None),

--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -70,7 +70,9 @@ class BatchOperationsImpl:
         self.table_name = table_name
         self.schema = schema
         if recreate not in ("auto", "always", "never"):
-            raise ValueError("recreate may be one of 'auto', 'always', or 'never'.")
+            raise ValueError(
+                "recreate may be one of 'auto', 'always', or 'never'."
+            )
         self.recreate = recreate
         self.copy_from = copy_from
         self.table_args = table_args
@@ -147,7 +149,8 @@ class BatchOperationsImpl:
                     from sqlalchemy import inspect as sqla_inspect
 
                     self.operations.impl.autogen_table_reflect(
-                        sqla_inspect(self.operations.get_bind()), existing_table
+                        sqla_inspect(self.operations.get_bind()),
+                        existing_table,
                     )
                     reflected = True
 
@@ -230,9 +233,13 @@ class ApplyBatchImpl:
         self.new_table: Optional[Table] = None
 
         self.partial_reordering = partial_reordering  # tuple of tuples
-        self.add_col_ordering: Tuple[Tuple[str, str], ...] = ()  # tuple of tuples
+        self.add_col_ordering: Tuple[
+            Tuple[str, str], ...
+        ] = ()  # tuple of tuples
 
-        self.column_transfers = OrderedDict((c.name, {"expr": c}) for c in self.table.c)
+        self.column_transfers = OrderedDict(
+            (c.name, {"expr": c}) for c in self.table.c
+        )
         self.existing_ordering = list(self.column_transfers)
 
         self.reflected = reflected
@@ -263,7 +270,9 @@ class ApplyBatchImpl:
             if _is_type_bound(const):
                 continue
             elif (
-                self.reflected and isinstance(const, CheckConstraint) and not const.name
+                self.reflected
+                and isinstance(const, CheckConstraint)
+                and not const.name
             ):
                 # TODO: we are skipping unnamed reflected CheckConstraint
                 # because
@@ -333,7 +342,9 @@ class ApplyBatchImpl:
             **self.table_kwargs,
         )
 
-        for const in list(self.named_constraints.values()) + self.unnamed_constraints:
+        for const in (
+            list(self.named_constraints.values()) + self.unnamed_constraints
+        ):
             const_columns = {c.key for c in _columns_for_constraint(const)}
 
             if not const_columns.issubset(self.column_transfers):
@@ -348,14 +359,18 @@ class ApplyBatchImpl:
                     # FK constraints from other tables; we assume SQLite
                     # no foreign keys just keeps the names unchanged, so
                     # when we rename back, they match again.
-                    const_copy = _copy(const, schema=schema, target_table=self.table)
+                    const_copy = _copy(
+                        const, schema=schema, target_table=self.table
+                    )
                 else:
                     # "target_table" for ForeignKeyConstraint.copy() is
                     # only used if the FK is detected as being
                     # self-referential, which we are handling above.
                     const_copy = _copy(const, schema=schema)
             else:
-                const_copy = _copy(const, schema=schema, target_table=new_table)
+                const_copy = _copy(
+                    const, schema=schema, target_table=new_table
+                )
             if isinstance(const, ForeignKeyConstraint):
                 self._setup_referent(m, const)
             new_table.append_constraint(const_copy)
@@ -423,7 +438,8 @@ class ApplyBatchImpl:
                     *[
                         Column(n, sqltypes.NULLTYPE)
                         for n in [
-                            colspec(elem).split(".")[-1] for elem in constraint.elements
+                            colspec(elem).split(".")[-1]
+                            for elem in constraint.elements
                         ]
                     ],
                     schema=referent_schema,
@@ -475,7 +491,9 @@ class ApplyBatchImpl:
         table_name: str,
         column_name: str,
         nullable: Optional[bool] = None,
-        server_default: Union[_ServerDefaultType, None, Literal[False]] = False,
+        server_default: Union[
+            _ServerDefaultType, None, Literal[False]
+        ] = False,
         name: Optional[str] = None,
         type_: Optional[TypeEngine] = None,
         autoincrement: Optional[Union[bool, Literal["auto"]]] = None,
@@ -519,7 +537,9 @@ class ApplyBatchImpl:
                     existing.type.create_constraint  # type:ignore[attr-defined] # noqa
                 ) = False
 
-            self.impl.cast_for_batch_migrate(existing, existing_transfer, type_)
+            self.impl.cast_for_batch_migrate(
+                existing, existing_transfer, type_
+            )
 
             existing.type = type_
 
@@ -562,7 +582,9 @@ class ApplyBatchImpl:
                             insert_before = index_cols[idx]
                     else:
                         # insert after a column that is also new
-                        insert_before = dict(self.add_col_ordering)[insert_after]
+                        insert_before = dict(self.add_col_ordering)[
+                            insert_after
+                        ]
             if insert_before:
                 if not insert_after:
                     if insert_before in col_indexes:
@@ -572,9 +594,9 @@ class ApplyBatchImpl:
                             insert_after = index_cols[idx]
                     else:
                         # insert before a column that is also new
-                        insert_after = {b: a for a, b in self.add_col_ordering}[
-                            insert_before
-                        ]
+                        insert_after = {
+                            b: a for a, b in self.add_col_ordering
+                        }[insert_before]
 
         if insert_before:
             self.add_col_ordering += ((colname, insert_before),)
@@ -612,7 +634,9 @@ class ApplyBatchImpl:
         **kw,
     ) -> None:
         if column.name in self.table.primary_key.columns:
-            _remove_column_from_collection(self.table.primary_key.columns, column)
+            _remove_column_from_collection(
+                self.table.primary_key.columns, column
+            )
         del self.columns[column.name]
         del self.column_transfers[column.name]
         self.existing_ordering.remove(column.name)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -72,7 +72,9 @@ class BatchApplyTest(TestBase):
             Column("x", String(10)),
             Column("y", Integer),
         )
-        return ApplyBatchImpl(self.impl, t, table_args, table_kwargs, False, **kw)
+        return ApplyBatchImpl(
+            self.impl, t, table_args, table_kwargs, False, **kw
+        )
 
     def _uq_fixture(self, table_args=(), table_kwargs={}):
         m = MetaData()
@@ -133,7 +135,9 @@ class BatchApplyTest(TestBase):
         )
         return ApplyBatchImpl(self.impl, t, (), {}, False)
 
-    def _literal_ck_fixture(self, copy_from=None, table_args=(), table_kwargs={}):
+    def _literal_ck_fixture(
+        self, copy_from=None, table_args=(), table_kwargs={}
+    ):
         m = MetaData()
         if copy_from is not None:
             t = copy_from
@@ -275,7 +279,9 @@ class BatchApplyTest(TestBase):
         pk_cols = [col for col in impl.new_table.c if col.primary_key]
         eq_(list(impl.new_table.primary_key), pk_cols)
 
-        create_stmt = str(CreateTable(impl.new_table).compile(dialect=context.dialect))
+        create_stmt = str(
+            CreateTable(impl.new_table).compile(dialect=context.dialect)
+        )
         create_stmt = re.sub(r"[\n\t]", "", create_stmt)
 
         idx_stmt = ""
@@ -308,7 +314,11 @@ class BatchApplyTest(TestBase):
         args["temp_name"] = impl.new_table.name
 
         args["colnames"] = ", ".join(
-            [impl.new_table.c[name].name for name in colnames if name in impl.table.c]
+            [
+                impl.new_table.c[name].name
+                for name in colnames
+                if name in impl.table.c
+            ]
         )
 
         args["tname_colnames"] = ", ".join(
@@ -336,7 +346,8 @@ class BatchApplyTest(TestBase):
                 "INSERT INTO %(schema)s%(temp_name)s (%(colnames)s) "
                 "SELECT %(tname_colnames)s FROM %(schema)stname" % args,
                 "DROP TABLE %(schema)stname" % args,
-                "ALTER TABLE %(schema)s%(temp_name)s RENAME TO %(schema)stname" % args,
+                "ALTER TABLE %(schema)s%(temp_name)s RENAME TO %(schema)stname"
+                % args,
             ]
         )
         if idx_stmt:
@@ -462,7 +473,13 @@ class BatchApplyTest(TestBase):
             colnames=["id", "email"],
         )
         eq_(
-            len([c for c in new_table.constraints if isinstance(c, CheckConstraint)]),
+            len(
+                [
+                    c
+                    for c in new_table.constraints
+                    if isinstance(c, CheckConstraint)
+                ]
+            ),
             1,
         )
 
@@ -486,7 +503,13 @@ class BatchApplyTest(TestBase):
             colnames=["id", "email"],
         )
         eq_(
-            len([c for c in new_table.constraints if isinstance(c, CheckConstraint)]),
+            len(
+                [
+                    c
+                    for c in new_table.constraints
+                    if isinstance(c, CheckConstraint)
+                ]
+            ),
             1,
         )
         eq_(new_table.c.email.name, "emol")
@@ -501,7 +524,13 @@ class BatchApplyTest(TestBase):
             colnames=["id", "email"],
         )
         eq_(
-            len([c for c in new_table.constraints if isinstance(c, CheckConstraint)]),
+            len(
+                [
+                    c
+                    for c in new_table.constraints
+                    if isinstance(c, CheckConstraint)
+                ]
+            ),
             1,
         )
 
@@ -573,7 +602,9 @@ class BatchApplyTest(TestBase):
         # operations.add_column produces a table
         impl.add_column("tname", Column("g", Integer), insert_after="id")
         impl.add_column("tname", Column("q", Integer))
-        new_table = self._assert_impl(impl, colnames=["id", "g", "x", "y", "q"])
+        new_table = self._assert_impl(
+            impl, colnames=["id", "g", "x", "y", "q"]
+        )
         eq_(new_table.c.g.name, "g")
 
     def test_add_col_no_order_plus_insert_after(self):
@@ -583,21 +614,27 @@ class BatchApplyTest(TestBase):
         t = self.op.schema_obj.table("tname", col)  # noqa
         impl.add_column("tname", Column("q", Integer))
         impl.add_column("tname", Column("g", Integer), insert_after="id")
-        new_table = self._assert_impl(impl, colnames=["id", "g", "x", "y", "q"])
+        new_table = self._assert_impl(
+            impl, colnames=["id", "g", "x", "y", "q"]
+        )
         eq_(new_table.c.g.name, "g")
 
     def test_add_col_insert_after_another_insert(self):
         impl = self._simple_fixture()
         impl.add_column("tname", Column("g", Integer), insert_after="id")
         impl.add_column("tname", Column("q", Integer), insert_after="g")
-        new_table = self._assert_impl(impl, colnames=["id", "g", "q", "x", "y"])
+        new_table = self._assert_impl(
+            impl, colnames=["id", "g", "q", "x", "y"]
+        )
         eq_(new_table.c.g.name, "g")
 
     def test_add_col_insert_before_another_insert(self):
         impl = self._simple_fixture()
         impl.add_column("tname", Column("g", Integer), insert_after="id")
         impl.add_column("tname", Column("q", Integer), insert_before="g")
-        new_table = self._assert_impl(impl, colnames=["id", "q", "g", "x", "y"])
+        new_table = self._assert_impl(
+            impl, colnames=["id", "q", "g", "x", "y"]
+        )
         eq_(new_table.c.g.name, "g")
 
     def test_add_server_default(self):
@@ -617,7 +654,9 @@ class BatchApplyTest(TestBase):
     def test_rename_col_pk(self):
         impl = self._simple_fixture()
         impl.alter_column("tname", "id", name="foobar")
-        new_table = self._assert_impl(impl, ddl_contains="PRIMARY KEY (foobar)")
+        new_table = self._assert_impl(
+            impl, ddl_contains="PRIMARY KEY (foobar)"
+        )
         eq_(new_table.c.id.name, "foobar")
         eq_(list(new_table.primary_key), [new_table.c.id])
 
@@ -630,7 +669,9 @@ class BatchApplyTest(TestBase):
             ddl_contains='FOREIGN KEY(foobar) REFERENCES "user" (id)',
         )
         eq_(new_table.c.user_id.name, "foobar")
-        eq_(list(new_table.c.user_id.foreign_keys)[0]._get_colspec(), "user.id")
+        eq_(
+            list(new_table.c.user_id.foreign_keys)[0]._get_colspec(), "user.id"
+        )
 
     def test_regen_multi_fk(self):
         impl = self._multi_fk_fixture()
@@ -673,7 +714,9 @@ class BatchApplyTest(TestBase):
         user = Table("user", meta, cid)
 
         fk = [
-            c for c in impl.unnamed_constraints if isinstance(c, ForeignKeyConstraint)
+            c
+            for c in impl.unnamed_constraints
+            if isinstance(c, ForeignKeyConstraint)
         ]
         impl._setup_referent(meta, fk[0])
         is_(user.c.id, cid)
@@ -732,9 +775,13 @@ class BatchApplyTest(TestBase):
         new_table = self._assert_impl(
             impl,
             colnames=["id", "x", "y", "user_id"],
-            ddl_contains='CONSTRAINT fk1 FOREIGN KEY(user_id) REFERENCES "user" (id)',
+            ddl_contains=(
+                "CONSTRAINT fk1 FOREIGN KEY(user_id) " 'REFERENCES "user" (id)'
+            ),
         )
-        eq_(list(new_table.c.user_id.foreign_keys)[0]._get_colspec(), "user.id")
+        eq_(
+            list(new_table.c.user_id.foreign_keys)[0]._get_colspec(), "user.id"
+        )
 
     def test_drop_fk(self):
         impl = self._named_fk_fixture()
@@ -933,12 +980,18 @@ class BatchAPITest(TestBase):
                     self.mock_schema.Column(),
                     schema=None,
                 ),
-                mock.call().append_constraint(self.mock_schema.ForeignKeyConstraint()),
+                mock.call().append_constraint(
+                    self.mock_schema.ForeignKeyConstraint()
+                ),
             ],
         )
         eq_(
             batch.impl.operations.impl.mock_calls,
-            [mock.call.add_constraint(self.mock_schema.ForeignKeyConstraint())],
+            [
+                mock.call.add_constraint(
+                    self.mock_schema.ForeignKeyConstraint()
+                )
+            ],
         )
 
     def test_create_fk_schema(self):
@@ -975,12 +1028,18 @@ class BatchAPITest(TestBase):
                     self.mock_schema.Column(),
                     schema="foo",
                 ),
-                mock.call().append_constraint(self.mock_schema.ForeignKeyConstraint()),
+                mock.call().append_constraint(
+                    self.mock_schema.ForeignKeyConstraint()
+                ),
             ],
         )
         eq_(
             batch.impl.operations.impl.mock_calls,
-            [mock.call.add_constraint(self.mock_schema.ForeignKeyConstraint())],
+            [
+                mock.call.add_constraint(
+                    self.mock_schema.ForeignKeyConstraint()
+                )
+            ],
         )
 
     def test_create_uq(self):
@@ -1028,7 +1087,11 @@ class BatchAPITest(TestBase):
         )
         eq_(
             batch.impl.operations.impl.mock_calls,
-            [mock.call.add_constraint(self.mock_schema.PrimaryKeyConstraint())],
+            [
+                mock.call.add_constraint(
+                    self.mock_schema.PrimaryKeyConstraint()
+                )
+            ],
         )
 
     def test_create_check(self):
@@ -1075,7 +1138,9 @@ class CopyFromTest(TestBase):
         context = self._fixture()
         self.table.append_column(Column("toj", Text))
         self.table.append_column(Column("fromj", JSON))
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.alter_column("data", type_=Integer)
             batch_op.alter_column("toj", type_=JSON)
             batch_op.alter_column("fromj", type_=Text)
@@ -1096,7 +1161,9 @@ class CopyFromTest(TestBase):
             Column("y", Boolean(create_constraint=True, name="ck1"))
         )
 
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.alter_column(
                 "y",
                 type_=Integer,
@@ -1114,9 +1181,13 @@ class CopyFromTest(TestBase):
     def test_change_name_from_existing_variant_type(self):
         """test #982"""
         context = self._fixture()
-        self.table.append_column(Column("y", Text().with_variant(Text(10000), "mysql")))
+        self.table.append_column(
+            Column("y", Text().with_variant(Text(10000), "mysql"))
+        )
 
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.alter_column(
                 column_name="y",
                 new_column_name="q",
@@ -1135,7 +1206,9 @@ class CopyFromTest(TestBase):
         context = self._fixture()
         self.table.append_column(Column("y", Integer))
 
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.alter_column(
                 "y",
                 existing_type=Integer,
@@ -1188,7 +1261,9 @@ class CopyFromTest(TestBase):
 
     def test_create_drop_index_wo_always(self):
         context = self._fixture()
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.create_index("ix_data", ["data"], unique=True)
 
         context.assert_("CREATE UNIQUE INDEX ix_data ON foo (data)")
@@ -1196,14 +1271,18 @@ class CopyFromTest(TestBase):
         context.clear_assertions()
 
         Index("ix_data", self.table.c.data, unique=True)
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.drop_index("ix_data")
 
         context.assert_("DROP INDEX ix_data")
 
     def test_create_drop_index_w_other_ops(self):
         context = self._fixture()
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.alter_column("data", type_=Integer)
             batch_op.create_index("ix_data", ["data"], unique=True)
 
@@ -1220,7 +1299,9 @@ class CopyFromTest(TestBase):
         context.clear_assertions()
 
         Index("ix_data", self.table.c.data, unique=True)
-        with self.op.batch_alter_table("foo", copy_from=self.table) as batch_op:
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
             batch_op.drop_index("ix_data")
             batch_op.alter_column("data", type_=String)
 
@@ -1571,8 +1652,12 @@ class BatchRoundTripTest(TestBase):
         )
         with self.conn.begin():
             bar.create(self.conn)
-            self.conn.execute(bar.insert(), {"id": 1, "data": "x", "bar_id": None})
-            self.conn.execute(bar.insert(), {"id": 2, "data": "y", "bar_id": 1})
+            self.conn.execute(
+                bar.insert(), {"id": 1, "data": "x", "bar_id": None}
+            )
+            self.conn.execute(
+                bar.insert(), {"id": 2, "data": "y", "bar_id": 1}
+            )
 
         with self.op.batch_alter_table("bar", recreate=recreate) as batch_op:
             batch_op.alter_column(
@@ -1679,7 +1764,9 @@ class BatchRoundTripTest(TestBase):
             batch_op.create_check_constraint("newck", text("x > 0"))
 
         ck_consts = inspect(self.conn).get_check_constraints("foo")
-        ck_consts[0]["sqltext"] = re.sub(r"[\'\"`\(\)]", "", ck_consts[0]["sqltext"])
+        ck_consts[0]["sqltext"] = re.sub(
+            r"[\'\"`\(\)]", "", ck_consts[0]["sqltext"]
+        )
         for ck in ck_consts:
             ck.pop("comment", None)
         eq_(ck_consts, [{"sqltext": "x > 0", "name": "newck"}])
@@ -1689,7 +1776,9 @@ class BatchRoundTripTest(TestBase):
     def test_drop_ck_constraint(self, recreate):
         self._ck_constraint_fixture()
 
-        with self.op.batch_alter_table("ck_table", recreate=recreate) as batch_op:
+        with self.op.batch_alter_table(
+            "ck_table", recreate=recreate
+        ) as batch_op:
             batch_op.drop_constraint("ck", type_="check")
 
         ck_consts = inspect(self.conn).get_check_constraints("ck_table")
@@ -1699,7 +1788,9 @@ class BatchRoundTripTest(TestBase):
     def test_drop_ck_constraint_legacy_type(self):
         self._ck_constraint_fixture()
 
-        with self.op.batch_alter_table("ck_table", recreate="always") as batch_op:
+        with self.op.batch_alter_table(
+            "ck_table", recreate="always"
+        ) as batch_op:
             # matches the docs that were written for this originally
             batch_op.drop_constraint("ck", "check")
 
@@ -1845,7 +1936,9 @@ class BatchRoundTripTest(TestBase):
     @config.requirements.comments
     def test_alter_column_comment(self):
         with self.op.batch_alter_table("foo") as batch_op:
-            batch_op.alter_column("x", existing_type=Integer(), comment="some comment")
+            batch_op.alter_column(
+                "x", existing_type=Integer(), comment="some comment"
+            )
 
         self._assert_column_comment("foo", "x", "some comment")
 
@@ -1908,7 +2001,9 @@ class BatchRoundTripTest(TestBase):
                 "flag", new_column_name="bflag", existing_type=Boolean
             )
 
-        self._assert_data([{"id": 1, "bflag": True}, {"id": 2, "bflag": False}], "bar")
+        self._assert_data(
+            [{"id": 1, "bflag": True}, {"id": 2, "bflag": False}], "bar"
+        )
 
     #    @config.requirements.check_constraint_reflection
     def test_rename_column_boolean_named_ck(self):
@@ -1931,7 +2026,9 @@ class BatchRoundTripTest(TestBase):
                 existing_type=Boolean(create_constraint=True, name="ck1"),
             )
 
-        self._assert_data([{"id": 1, "bflag": True}, {"id": 2, "bflag": False}], "bar")
+        self._assert_data(
+            [{"id": 1, "bflag": True}, {"id": 2, "bflag": False}], "bar"
+        )
 
     @config.requirements.non_native_boolean
     def test_rename_column_non_native_boolean_no_ck(self):
@@ -2001,7 +2098,9 @@ class BatchRoundTripTest(TestBase):
     def test_add_column_auto(self):
         # note this uses ALTER
         with self.op.batch_alter_table("foo") as batch_op:
-            batch_op.add_column(Column("data2", String(50), server_default="hi"))
+            batch_op.add_column(
+                Column("data2", String(50), server_default="hi")
+            )
 
         self._assert_data(
             [
@@ -2049,7 +2148,9 @@ class BatchRoundTripTest(TestBase):
         """test #883"""
         with self.op.batch_alter_table("foo") as batch_op:
             batch_op.add_column(
-                Column("data2", Integer, Computed("1 + 1", persisted=persisted))
+                Column(
+                    "data2", Integer, Computed("1 + 1", persisted=persisted)
+                )
             )
 
         self._assert_data(
@@ -2143,7 +2244,9 @@ class BatchRoundTripTest(TestBase):
 
     def test_add_column_recreate(self):
         with self.op.batch_alter_table("foo", recreate="always") as batch_op:
-            batch_op.add_column(Column("data2", String(50), server_default="hi"))
+            batch_op.add_column(
+                Column("data2", String(50), server_default="hi")
+            )
 
         self._assert_data(
             [
@@ -2209,7 +2312,9 @@ class BatchRoundTripTest(TestBase):
         with self.op.batch_alter_table("t", recreate="always") as batch_op:
             batch_op.drop_column("data")
 
-        sql = self.conn.scalar(text("SELECT sql FROM sqlite_master WHERE name='t'"))
+        sql = self.conn.scalar(
+            text("SELECT sql FROM sqlite_master WHERE name='t'")
+        )
         assert "STRICT" in sql
 
     def test_sqlite_batch_without_rowid(self):
@@ -2226,7 +2331,9 @@ class BatchRoundTripTest(TestBase):
         with self.op.batch_alter_table("t2", recreate="always") as batch_op:
             batch_op.add_column(Column("new_col", Integer))
 
-        sql = self.conn.scalar(text("SELECT sql FROM sqlite_master WHERE name='t2'"))
+        sql = self.conn.scalar(
+            text("SELECT sql FROM sqlite_master WHERE name='t2'")
+        )
         assert "WITHOUT ROWID" in sql
 
 
@@ -2323,7 +2430,9 @@ class BatchRoundTripPostgresqlTest(BatchRoundTripTest):
         with self.op.batch_alter_table(
             "has_native_bool",
             recreate="always",
-            reflect_kwargs={"listeners": [("column_reflect", listen_for_reflect)]},
+            reflect_kwargs={
+                "listeners": [("column_reflect", listen_for_reflect)]
+            },
         ) as batch_op:
             batch_op.add_column(Column("data", Integer))
 
@@ -2358,7 +2467,9 @@ class OfflineTest(TestBase):
             self.a = a = util.rev_id()
 
             script = ScriptDirectory.from_config(cfg)
-            script.generate_revision(a, "revision a", refresh=True, head="base")
+            script.generate_revision(
+                a, "revision a", refresh=True, head="base"
+            )
             write_script(
                 script,
                 a,
@@ -2411,7 +2522,9 @@ class OfflineTest(TestBase):
             self.a = a = util.rev_id()
 
             script = ScriptDirectory.from_config(cfg)
-            script.generate_revision(a, "revision a", refresh=True, head="base")
+            script.generate_revision(
+                a, "revision a", refresh=True, head="base"
+            )
             write_script(
                 script,
                 a,
@@ -2457,7 +2570,9 @@ class OfflineTest(TestBase):
 
         with capture_context_buffer() as buf:
             command.downgrade(self.cfg, f"{self.a}:base", sql=True)
-        assert re.search(r"ALTER TABLE some_table DROP COLUMN foo", buf.getvalue())
+        assert re.search(
+            r"ALTER TABLE some_table DROP COLUMN foo", buf.getvalue()
+        )
 
     def test_upgrade_batch_fails_gracefully(self, batch_fixture):
         batch_fixture("sqlite")
@@ -2487,7 +2602,9 @@ class OfflineTest(TestBase):
         with capture_context_buffer() as buf:
             command.upgrade(self.cfg, self.a, sql=True)
 
-        assert re.search(r"CREATE TABLE _alembic_tmp_some_table", buf.getvalue())
+        assert re.search(
+            r"CREATE TABLE _alembic_tmp_some_table", buf.getvalue()
+        )
 
     def test_downgrade_batch_no_reflection(self, no_reflect_batch_fixture):
         no_reflect_batch_fixture()
@@ -2495,4 +2612,6 @@ class OfflineTest(TestBase):
         with capture_context_buffer() as buf:
             command.downgrade(self.cfg, f"{self.a}:base", sql=True)
 
-        assert re.search(r"CREATE TABLE _alembic_tmp_some_table", buf.getvalue())
+        assert re.search(
+            r"CREATE TABLE _alembic_tmp_some_table", buf.getvalue()
+        )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes: #1758 
### Description
<!-- Describe your changes in detail -->
This PR addresses Issue #1758 where SQLite tables created with special keywords like `STRICT` or `WITHOUT ROWID` lost these properties whenever a batch migration was performed (e.g., dropping a column or changing a type).

Since SQLAlchemy's standard reflection does not currently capture these SQLite-specific table arguments, Alembic's batch mode would "forget" them when recreating the table.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
