### PR TITLE
Add --splice support to merge command

### DIFF
--- a/alembic/command.py
+++ b/alembic/command.py
@@ -385,6 +385,7 @@ def merge(
     message: Optional[str] = None,
     branch_label: Optional[_RevIdType] = None,
     rev_id: Optional[str] = None,
+    splice: bool = False,
 ) -> Optional[Script]:
     """Merge two revisions together.  Creates a new migration file.
 
@@ -398,6 +399,9 @@ def merge(
 
     :param rev_id: hardcoded revision identifier instead of generating a new
      one.
+
+    :param splice: if True, allow the merge to create a new branch point
+     even if the given revisions are not heads.
 
     .. seealso::
 
@@ -435,6 +439,7 @@ def merge(
         refresh=True,
         head=revisions,
         branch_labels=branch_label,
+        splice=splice,
         **template_args,  # type:ignore[arg-type]
     )
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -276,6 +276,36 @@ finally:
 
         assert os.path.exists(rev.path)
 
+    def test_merge_cmd_splice(self):
+        """merge with --splice allows non-head revisions to be merged."""
+        cfg = self.cfg
+        self.a, self.b, self.c = three_rev_fixture(cfg)
+        self.d, self.e, self.f = multi_heads_fixture(
+            cfg, self.a, self.b, self.c
+        )
+        # e and f are heads, but b is not a head.
+        # merging b and c (at least one is not a head) should fail
+        # without splice.
+        assert_raises_message(
+            util.CommandError,
+            "please specify --splice",
+            command.merge,
+            self.cfg,
+            [self.b, self.d],
+            rev_id="should_fail",
+        )
+        # with splice=True, it should succeed
+        command.merge(
+            self.cfg,
+            [self.b, self.d],
+            rev_id="splice_merge",
+            splice=True,
+        )
+        rev = ScriptDirectory.from_config(self.cfg).get_revision(
+            "splice_merge"
+        )
+        assert os.path.exists(rev.path)
+
 
 class CurrentTest(_BufMixin, TestBase):
     @classmethod


### PR DESCRIPTION
Fixes #1712

Adds a `splice` parameter to the `merge()` command function, matching the existing support in `revision()`. This is wired through to `generate_revision()` and since `splice` is already registered in `_KWARGS_OPTS`, the `--splice` CLI flag is automatically available for `alembic merge`.

Without this, trying to merge non-head revisions raises an error that suggests using `--splice`, but the merge command didn't actually accept that flag.

The patch is exactly what @zzzeek proposed in the linked discussion. Test included that verifies both the error without `splice` and success with `splice=True`.
