### PR TITLE
Fix : TypeDecorator rendering to preserve SchemaType name/schema 

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -698,7 +698,7 @@ def _uq_constraint(
 
 
 def _user_autogenerate_prefix(autogen_context, target):
-    prefix = autogen_context.opts["user_module_prefix"]
+    prefix = autogen_context.opts.get("user_module_prefix", None)
     if prefix is None:
         return "%s." % target.__module__
     else:
@@ -856,6 +856,20 @@ def _render_fetched_value(autogen_context: AutogenContext) -> str:
     return "%(prefix)sFetchedValue()" % {
         "prefix": _sqlalchemy_autogenerate_prefix(autogen_context),
     }
+def _type_repr(type_: sqltypes.TypeEngine) -> str:
+    res = repr(type_)
+    if isinstance(type_, sqltypes.TypeDecorator) and isinstance(
+        type_.impl, sqltypes.SchemaType
+    ):
+        for attr in ("name", "schema"):
+            val = getattr(type_.impl, attr, None)
+            if val is not None and f"{attr}=" not in res:
+                if res.endswith("()"):
+                    res = res[:-1] + "%s=%r)" % (attr, val)
+                else:
+                    res = res[:-1] + ", %s=%r)" % (attr, val)
+    return res
+
 
 
 def _repr_type(
@@ -888,7 +902,7 @@ def _repr_type(
         if impl_rt:
             return impl_rt
         else:
-            return "%s.%r" % (dname, type_)
+            return "%s.%s" % (dname, _type_repr(type_))
     elif impl_rt:
         return impl_rt
     elif mod.startswith("sqlalchemy."):
@@ -897,10 +911,10 @@ def _repr_type(
             return fn(type_, autogen_context)
         else:
             prefix = _sqlalchemy_autogenerate_prefix(autogen_context)
-            return "%s%r" % (prefix, type_)
+            return "%s%s" % (prefix, _type_repr(type_))
     else:
         prefix = _user_autogenerate_prefix(autogen_context, type_)
-        return "%s%r" % (prefix, type_)
+        return "%s%s" % (prefix, _type_repr(type_))
 
 
 def _render_ARRAY_type(type_: ARRAY, autogen_context: AutogenContext) -> str:

--- a/tests/test_autogen_render.py
+++ b/tests/test_autogen_render.py
@@ -1797,6 +1797,38 @@ class AutogenRenderTest(TestBase):
             f"sa.Enum('one', 'two', 'three'{extra}, native_enum=False)",
         )
 
+    def test_render_enum_subclass(self):
+        class Enum1(Enum):
+            pass
+
+        enum = Enum1("one", "two", name="enum1")
+        eq_ignore_whitespace(
+            autogenerate.render._repr_type(enum, self.autogen_context),
+            f"{self.__class__.__module__}.Enum1('one', 'two', name='enum1')",
+        )
+
+    def test_render_typedecorator_enum(self):
+        class Enum2(types.TypeDecorator):
+            impl = Enum
+            cache_ok = True
+
+        enum = Enum2("one", "two", name="enum2")
+        eq_ignore_whitespace(
+            autogenerate.render._repr_type(enum, self.autogen_context),
+            f"{self.__class__.__module__}.Enum2('one', 'two', name='enum2')",
+        )
+
+    def test_render_typedecorator_boolean(self):
+        class MyBool(types.TypeDecorator):
+            impl = Boolean
+            cache_ok = True
+
+        type_ = MyBool(name="bool_ck")
+        eq_ignore_whitespace(
+            autogenerate.render._repr_type(type_, self.autogen_context),
+            f"{self.__class__.__module__}.MyBool(name='bool_ck')",
+        )
+
     def test_repr_plain_sqla_type(self):
         type_ = Integer()
         eq_ignore_whitespace(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Fixes Issue : sqlalchemy/sqlalchemy#13140 

### Description
This pull request fixes Issue sqlalchemy/sqlalchemy#13140, where `sqlalchemy.Enum` (and other `SchemaTypes` like `Boolean`) lost their `name `and schema properties when augmented with a `sqlalchemy.types.TypeDecorator` during autogenerated migrations.

The Fix: I have introduced a `_type_repr` helper in `alembic/autogenerate/render.py` that specifically detects `TypeDecorator` instances. If the implementation of the decorator is a `SchemaType`, Alembic now manually ensures that the `name` and `schema` attributes are preserved in the rendered migration string.

Additionally, `_user_autogenerate_prefix` was updated to use `.get()` instead of direct dictionary access to prevent `KeyError` regressions in certain testing environments where the full autogenerate context might not be initialized.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**