### PR TITLE
Fix typos in docstrings (contraint, funciton, priorty)

### DIFF
--- a/alembic/op.pyi
+++ b/alembic/op.pyi
@@ -86,7 +86,7 @@ def add_column(
 
     .. note::
 
-        Not all contraint types may be indicated with this directive.
+        Not all constraint types may be indicated with this directive.
         NOT NULL, FOREIGN KEY, and CHECK are honored, PRIMARY KEY
         is conditionally honored, UNIQUE
         is currently not.

--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -652,7 +652,7 @@ class Operations(AbstractOperations):
 
             .. note::
 
-                Not all contraint types may be indicated with this directive.
+                Not all constraint types may be indicated with this directive.
                 NOT NULL, FOREIGN KEY, and CHECK are honored, PRIMARY KEY
                 is conditionally honored, UNIQUE
                 is currently not.

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -2123,7 +2123,7 @@ class AddColumnOp(AlterTableOp):
 
         .. note::
 
-            Not all contraint types may be indicated with this directive.
+            Not all constraint types may be indicated with this directive.
             NOT NULL, FOREIGN KEY, and CHECK are honored, PRIMARY KEY
             is conditionally honored, UNIQUE
             is currently not.

--- a/alembic/util/langhelpers.py
+++ b/alembic/util/langhelpers.py
@@ -292,7 +292,7 @@ class DispatchPriority(enum.IntEnum):
     """
 
     FIRST = 50
-    """Run the funciton in the first batch of functions (highest priority)"""
+    """Run the function in the first batch of functions (highest priority)"""
 
     MEDIUM = 25
     """Run the function at normal priority (this is the default)"""
@@ -354,7 +354,7 @@ class Dispatcher:
 
 
 class PriorityDispatcher:
-    """registers lists of functions at multiple levels of priorty and provides
+    """registers lists of functions at multiple levels of priority and provides
     a target to invoke them in priority order.
 
     .. versionadded:: 1.18.0 - PriorityDispatcher replaces the job


### PR DESCRIPTION

**Repo:** sqlalchemy/alembic (⭐ 2700)
**Type:** docs
**Files changed:** 4
**Lines:** +5/-5

## What
Corrects three recurring spelling mistakes in user-visible docstrings: `contraint` → `constraint` (3 occurrences across `op.pyi`, `operations/base.py`, `operations/ops.py`), `funciton` → `function` and `priorty` → `priority` in `util/langhelpers.py`. The `op.pyi` stub change matches the autogenerated source so it stays consistent with `tools/write_pyi.py` output.

## Why
The misspellings appear in rendered API docs (e.g. `Operations.add_column`, `PriorityDispatcher`) and in IDE tooltips via the `.pyi` stub. Pure documentation polish — no behavior change.

## Testing
No runtime code paths touched; docstrings only. Verified with `git diff` that only string literals/comments were modified. No need to run the test suite.

## Risk
Low — docstring/comment-only edits, no functional change.
