### PR TITLE
docs: add Third-party Tools section with pytest-mrt

### DIFF
--- a/docs/build/front.rst
+++ b/docs/build/front.rst
@@ -116,6 +116,17 @@ part of the SQLAlchemy_ project.
 User issues, discussion of potential bugs and features are most easily
 discussed using `GitHub Discussions <https://github.com/sqlalchemy/alembic/discussions/>`_.
 
+.. _third_party_tools:
+
+Third-party Tools
+=================
+
+The following projects extend or complement Alembic:
+
+* `pytest-mrt <https://github.com/croc100/pytest-mrt>`_
+  A pytest plugin and CLI for verifying that Alembic (and Django) migrations
+  are safely reversible — detects rollback failures before they reach production.
+
 .. _bugs:
 
 Bugs


### PR DESCRIPTION
Adds a Third-party Tools section to `front.rst` for community projects that complement Alembic but don't fit the existing autogenerate extensions section.

First entry is [pytest-mrt](https://github.com/croc100/pytest-mrt) — a pytest plugin that tests whether migrations are safely reversible. Runs the actual up/down cycle with real data, and also does static analysis on migration files (missing downgrade, DROP COLUMN, no-op downgrade, etc.).

The autogenerate "Notable 3rd-party libraries" section felt too narrow for this — it's scoped to autogenerate extensions. Wasn't sure where else to put it so went with a new section between Community and Bugs.