### PR TITLE
Don't emit DROP of version table in offline mode at base (#1822)

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -639,9 +639,11 @@ class MigrationContext:
                         run_args=kw,
                     )
 
-        if self.as_sql and not head_maintainer.heads:
-            assert self.connection is not None
-            self._version.drop(self.connection)
+        # NOTE: offline ("--sql") mode intentionally does not emit a DROP
+        # of the version table when ending at base.  Online mode never drops
+        # the version table (e.g. ``downgrade base`` only deletes its row),
+        # so dropping it in offline mode only was an inconsistency present
+        # since the version table was first introduced.  See #1822.
 
     def _in_connection_transaction(self) -> bool:
         try:

--- a/docs/build/unreleased/1822.rst
+++ b/docs/build/unreleased/1822.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, commands
+    :tickets: 1822
+
+    Fixed inconsistency where running ``stamp`` or ``downgrade`` to ``base`` in
+    offline (``--sql``) mode would emit a ``DROP TABLE alembic_version``
+    statement, while the same operations in online mode never drop the version
+    table.  Offline mode no longer emits this ``DROP``, matching online
+    behavior.  The version table continues to be created when it does not exist;
+    only the spurious offline-only drop has been removed.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -988,10 +988,19 @@ class UpgradeDowngradeStampTest(TestBase):
             command.downgrade(self.cfg, "%s:base" % self.c, sql=True)
         assert "CREATE TABLE alembic_version" not in buf.getvalue()
         assert "INSERT INTO alembic_version" not in buf.getvalue()
-        assert "DROP TABLE alembic_version" in buf.getvalue()
+        # offline mode no longer drops the version table, matching online
+        # mode which never drops it.  See #1822.
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
         assert "DROP STEP 3" in buf.getvalue()
         assert "DROP STEP 2" in buf.getvalue()
         assert "DROP STEP 1" in buf.getvalue()
+
+    def test_sql_stamp_to_base_no_drop(self):
+        # stamping to "base" in offline mode must not emit a DROP of the
+        # version table; online mode never drops it.  See #1822.
+        with capture_context_buffer() as buf:
+            command.stamp(self.cfg, "base", sql=True)
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
 
     def test_version_to_middle(self):
         with capture_context_buffer() as buf:


### PR DESCRIPTION
Fixes #1822.

As diagnosed by @zzzeek in the issue, offline (`--sql`) mode emitted a `DROP TABLE alembic_version` when running `stamp` or `downgrade` to `base`, while online mode never drops the version table — an inconsistency dating to the version table's introduction.

This removes the offline-only `DROP` so both modes behave the same. The version table is still created when it does not exist; only the spurious offline drop is gone.

**Tests**
- Updated `UpgradeDowngradeStampTest::test_version_to_none` to assert the version table is no longer dropped in offline downgrade-to-base.
- Added `UpgradeDowngradeStampTest::test_sql_stamp_to_base_no_drop` regressing the exact scenario from the issue (`stamp --sql base`).
- Added a changelog entry under `docs/build/unreleased/`.

Full local run: 1763 passed (the only failures are pre-existing `test_post_write.py` hook tests unrelated to this change). `black` + `flake8` clean.