### PR TITLE
Avoid dropping version table for offline SQL base

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -639,10 +639,6 @@ class MigrationContext:
                         run_args=kw,
                     )
 
-        if self.as_sql and not head_maintainer.heads:
-            assert self.connection is not None
-            self._version.drop(self.connection)
-
     def _in_connection_transaction(self) -> bool:
         try:
             meth = self.connection.in_transaction  # type:ignore[union-attr]

--- a/docs/build/unreleased/1822.rst
+++ b/docs/build/unreleased/1822.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, commands
+    :tickets: 1822
+
+    Fixed SQL output for commands such as ``stamp base --sql`` and
+    ``downgrade ...:base --sql`` to no longer emit ``DROP TABLE`` for the
+    Alembic version table.  This now matches online mode, where Alembic
+    updates the version rows but does not drop the version table.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -988,7 +988,7 @@ class UpgradeDowngradeStampTest(TestBase):
             command.downgrade(self.cfg, "%s:base" % self.c, sql=True)
         assert "CREATE TABLE alembic_version" not in buf.getvalue()
         assert "INSERT INTO alembic_version" not in buf.getvalue()
-        assert "DROP TABLE alembic_version" in buf.getvalue()
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
         assert "DROP STEP 3" in buf.getvalue()
         assert "DROP STEP 2" in buf.getvalue()
         assert "DROP STEP 1" in buf.getvalue()
@@ -1046,6 +1046,11 @@ class UpgradeDowngradeStampTest(TestBase):
             "INSERT INTO alembic_version (version_num) VALUES ('%s')" % self.c
             in buf.getvalue()
         )
+
+    def test_sql_stamp_base_does_not_drop_version_table(self):
+        with capture_context_buffer() as buf:
+            command.stamp(self.cfg, "base", sql=True)
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
 
     def test_stamp_argparser_single_rev(self):
         cmd = config.CommandLine()


### PR DESCRIPTION
### Description

When offline SQL generation ends at `base`, Alembic emitted `DROP TABLE alembic_version`. This removes that offline-only table drop so SQL output matches online behavior: Alembic updates version rows but does not drop the version table.

Fixes #1822.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix
- [ ] A new feature implementation

### Validation

- `/tmp/alembic-pr-venv/bin/python -m pytest tests/test_command.py::UpgradeDowngradeStampTest -q`
- `/tmp/alembic-pr-venv/bin/python -m pytest tests/test_command.py -k stamp -q`
- `/tmp/alembic-pr-venv/bin/python -m pytest tests/test_command.py -q`
- `/tmp/alembic-pr-venv/bin/python -m compileall -q alembic/runtime/migration.py tests/test_command.py`
