### PR TITLE
Strip PostgreSQL type cast specifiers when comparing computed defaults

### DIFF
--- a/alembic/autogenerate/compare/server_defaults.py
+++ b/alembic/autogenerate/compare/server_defaults.py
@@ -21,6 +21,7 @@ from ...util import sqla_compat
 if TYPE_CHECKING:
     from sqlalchemy.sql.elements import quoted_name
     from sqlalchemy.sql.schema import Column
+    from sqlalchemy.engine import Dialect
 
     from ...autogenerate.api import AutogenContext
     from ...operations.ops import AlterColumnOp
@@ -48,7 +49,7 @@ def _render_server_default_for_compare(
         return None
 
 
-def _normalize_computed_default(sqltext: str) -> str:
+def _normalize_computed_default(sqltext: str, dialect: Dialect) -> str:
     """we want to warn if a computed sql expression has changed.  however
     we don't want false positives and the warning is not that critical.
     so filter out most forms of variability from the SQL text.
@@ -56,9 +57,12 @@ def _normalize_computed_default(sqltext: str) -> str:
     """
 
     normalized_sqltext = re.sub(r"[ \(\)'\"`\[\]\t\r\n]", "", sqltext).lower()
-    # strip postgresql type cast specifiers, e.g. ``::regconfig``, ``::text``,
-    # which can appear inconsistently and cause false-positive warnings.
-    return re.sub(r"::\w+", "", normalized_sqltext)
+    if dialect.name == "postgresql":
+        # strip postgresql type cast specifiers, e.g. ``::regconfig``,
+        # ``::text``, which can appear inconsistently on the reflected side
+        # only and cause false-positive warnings.
+        normalized_sqltext = re.sub(r"::\w+", "", normalized_sqltext)
+    return normalized_sqltext
 
 
 def _compare_computed_default(
@@ -97,7 +101,7 @@ def _compare_computed_default(
     # get a minimal comparison just to emit a warning.
 
     rendered_metadata_default = _normalize_computed_default(
-        rendered_metadata_default
+        rendered_metadata_default, autogen_context.dialect
     )
 
     if isinstance(conn_col.server_default, sa_schema.Computed):
@@ -108,7 +112,7 @@ def _compare_computed_default(
             )
         )
         rendered_conn_default = _normalize_computed_default(
-            rendered_conn_default
+            rendered_conn_default, autogen_context.dialect
         )
     else:
         rendered_conn_default = ""

--- a/alembic/autogenerate/compare/server_defaults.py
+++ b/alembic/autogenerate/compare/server_defaults.py
@@ -55,7 +55,10 @@ def _normalize_computed_default(sqltext: str) -> str:
 
     """
 
-    return re.sub(r"[ \(\)'\"`\[\]\t\r\n]", "", sqltext).lower()
+    normalized_sqltext = re.sub(r"[ \(\)'\"`\[\]\t\r\n]", "", sqltext).lower()
+    # strip postgresql type cast specifiers, e.g. ``::regconfig``, ``::text``,
+    # which can appear inconsistently and cause false-positive warnings.
+    return re.sub(r"::\w+", "", normalized_sqltext)
 
 
 def _compare_computed_default(

--- a/docs/build/unreleased/1462.rst
+++ b/docs/build/unreleased/1462.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, autogenerate, postgresql
+    :tickets: 1462
+
+    Fixed false-positive "Computed default cannot be modified" warning emitted
+    during autogenerate when comparing PostgreSQL ``Computed`` columns whose
+    reflected SQL expression includes type cast specifiers such as
+    ``::regconfig`` or ``::text``.  These cast specifiers are now stripped
+    before comparison so that semantically equivalent expressions no longer
+    trigger the warning.

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -72,6 +72,9 @@ if True:
     from alembic.autogenerate.compare.server_defaults import (
         _dialect_impl_compare_server_default as _compare_server_default,
     )
+    from alembic.autogenerate.compare.server_defaults import (
+        _normalize_computed_default,
+    )
 
 
 class PostgresqlOpTest(TestBase):
@@ -393,6 +396,20 @@ class PostgresqlOpTest(TestBase):
             "c1",
             server_default=sd(),
             existing_server_default=esd(),
+        )
+
+    def test_normalize_computed_default_strips_type_casts(self):
+        # type cast specifiers such as ``::regconfig`` only appear on the
+        # reflected (connection) side and would otherwise cause a
+        # false-positive "cannot be modified" warning.  issue #1462
+        eq_(
+            _normalize_computed_default(
+                "setweight(to_tsvector('english', title), 'a')"
+            ),
+            _normalize_computed_default(
+                "setweight(to_tsvector('english'::regconfig, "
+                "title::text), 'a'::\"char\")"
+            ),
         )
 
     @combinations(

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -21,6 +21,7 @@ from sqlalchemy import Table
 from sqlalchemy import text
 from sqlalchemy import types
 from sqlalchemy import UniqueConstraint
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.dialects.postgresql import ExcludeConstraint
@@ -402,13 +403,15 @@ class PostgresqlOpTest(TestBase):
         # type cast specifiers such as ``::regconfig`` only appear on the
         # reflected (connection) side and would otherwise cause a
         # false-positive "cannot be modified" warning.  issue #1462
+        dialect = postgresql.dialect()
         eq_(
             _normalize_computed_default(
-                "setweight(to_tsvector('english', title), 'a')"
+                "setweight(to_tsvector('english', title), 'a')", dialect
             ),
             _normalize_computed_default(
                 "setweight(to_tsvector('english'::regconfig, "
-                "title::text), 'a'::\"char\")"
+                "title::text), 'a'::\"char\")",
+                dialect,
             ),
         )
 


### PR DESCRIPTION
Fixes: #1462. On PostgreSQL, reflected computed-column expressions come back with type cast specifiers (e.g. `::regconfig`, `::text`, `::char`) that aren't present on the metadata side, causing autogenerate to raise a false-positive "Computed default ... cannot be modified" warning even when the expressions are equivalent.

Extends `_normalize_computed_default()` to strip those `::<type>` specifiers after the existing whitespace/quote normalization, so the two sides compare equal. Added a unit test normalizing the cast-laden expression from the issue against the cast-free one (fails without the fix, confirmed via `git stash`), plus a changelog entry under `docs/build/unreleased/`.

`tests/test_postgresql.py` passes (70 passed) and `ruff check` is clean on the touched files.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix
- [ ] A new feature implementation

**Have a nice day!**