### PR TITLE
Fix offline --sql mode incorrectly emitting DROP TABLE for alembic_version

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -639,9 +639,11 @@ class MigrationContext:
                         run_args=kw,
                     )
 
-        if self.as_sql and not head_maintainer.heads:
-            assert self.connection is not None
-            self._version.drop(self.connection)
+        # NOTE: offline ("--sql") mode intentionally does not emit a DROP
+        # of the version table when ending at base.  Online mode never drops
+        # the version table (e.g. ``downgrade base`` only deletes its rows),
+        # so dropping it in offline mode only was an inconsistency present
+        # since the version table was first introduced.  See #1822.
 
     def _in_connection_transaction(self) -> bool:
         try:

--- a/docs/build/unreleased/1822.rst
+++ b/docs/build/unreleased/1822.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, commands
+    :tickets: 1822
+
+    Fixed inconsistency where running ``stamp`` or ``downgrade`` to ``base``
+    in offline (``--sql``) mode would emit a ``DROP TABLE alembic_version``
+    statement, while the same operations in online mode never drop the version
+    table.  Offline mode no longer emits this ``DROP``, matching online
+    behavior.  The version table continues to be created when it does not
+    exist; only the spurious offline-only drop has been removed.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -988,7 +988,7 @@ class UpgradeDowngradeStampTest(TestBase):
             command.downgrade(self.cfg, "%s:base" % self.c, sql=True)
         assert "CREATE TABLE alembic_version" not in buf.getvalue()
         assert "INSERT INTO alembic_version" not in buf.getvalue()
-        assert "DROP TABLE alembic_version" in buf.getvalue()
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
         assert "DROP STEP 3" in buf.getvalue()
         assert "DROP STEP 2" in buf.getvalue()
         assert "DROP STEP 1" in buf.getvalue()
@@ -1046,6 +1046,13 @@ class UpgradeDowngradeStampTest(TestBase):
             "INSERT INTO alembic_version (version_num) VALUES ('%s')" % self.c
             in buf.getvalue()
         )
+
+    def test_sql_stamp_to_base_no_drop(self):
+        # stamping to "base" in offline mode must not emit a DROP of the
+        # version table; online mode never drops it.  See #1822.
+        with capture_context_buffer() as buf:
+            command.stamp(self.cfg, "base", sql=True)
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
 
     def test_stamp_argparser_single_rev(self):
         cmd = config.CommandLine()


### PR DESCRIPTION
## Summary

Running `alembic stamp base --sql` or `alembic downgrade <rev>:base --sql` incorrectly emits a `DROP TABLE alembic_version` statement. Online mode never drops the version table — it only deletes rows from it — so this was an inconsistency introduced in a very early commit (`2da7f004`) before the 0.1 release.

The maintainer confirmed this is a bug:
> "Alembic creates the version table if it does not exist but never drops it. In this case the DROP here is a specific rule added just for --sql mode and appears to be a coding mistake."

## Changes

**`alembic/runtime/migration.py`**
Removed the block in `MigrationContext.run_migrations()` that conditionally dropped the version table when `as_sql=True` and no heads remained. Added an explanatory comment for future readers.

**`tests/test_command.py`**
- Updated `test_version_to_none` assertion to expect `DROP TABLE alembic_version` is **not** present in `--sql` output.
- Added `test_sql_stamp_to_base_no_drop` to explicitly cover the `stamp base --sql` path.

**`docs/build/unreleased/1822.rst`**
Added changelog entry following Alembic'''s per-file changelog convention.

## Test results

```
1515 passed, 132 skipped in 4.27s
```
(Python 3.13.3 / SQLite; DB-specific and `test_post_write` skipped as expected)

Fixes #1822