### PR TITLE
Fix bare except clause in alembic/util/messaging.py

### DIFF
--- a/alembic/util/messaging.py
+++ b/alembic/util/messaging.py
@@ -58,7 +58,7 @@ def status(
     msg(status_msg + " ...", newline, flush=True, quiet=quiet)
     try:
         yield
-    except:
+    except Exception:
         if not quiet:
             write_outstream(sys.stdout, "  FAILED\n")
         raise


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the `status()` context manager.

The `status()` context manager prints a status message and a completion/failure indicator. Its bare `except:` catches `BaseException`, meaning `KeyboardInterrupt` or `SystemExit` during the operation would trigger the failure message and then re-raise — but the intent is clearly to catch operational exceptions, not signals. `except Exception:` is the correct type here.