### PR TITLE
fix: handle Path objects in version_locations

### DIFF
--- a/alembic/util/pyfiles.py
+++ b/alembic/util/pyfiles.py
@@ -51,7 +51,9 @@ def template_to_file(
             f.write(output)
 
 
-def coerce_resource_to_filename(fname_or_resource: str) -> pathlib.Path:
+def coerce_resource_to_filename(
+    fname_or_resource: Union[str, os.PathLike[str]]
+) -> pathlib.Path:
     """Interpret a filename as either a filesystem location or as a package
     resource.
 
@@ -60,21 +62,24 @@ def coerce_resource_to_filename(fname_or_resource: str) -> pathlib.Path:
 
     """
     # TODO: there seem to be zero tests for the package resource codepath
-    if not os.path.isabs(fname_or_resource) and ":" in fname_or_resource:
-        tokens = fname_or_resource.split(":")
+    if isinstance(fname_or_resource, str):
+        if not os.path.isabs(fname_or_resource) and ":" in fname_or_resource:
+            tokens = fname_or_resource.split(":")
 
-        # from https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename  # noqa E501
+            # from https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename  # noqa E501
 
-        file_manager = ExitStack()
-        atexit.register(file_manager.close)
+            file_manager = ExitStack()
+            atexit.register(file_manager.close)
 
-        ref = resources.files(tokens[0])
-        for tok in tokens[1:]:
-            ref = ref / tok
-        fname_or_resource = file_manager.enter_context(  # type: ignore[assignment]  # noqa: E501
-            resources.as_file(ref)
-        )
-    return pathlib.Path(fname_or_resource)
+            ref = resources.files(tokens[0])
+            for tok in tokens[1:]:
+                ref = ref / tok
+            fname_or_resource = file_manager.enter_context(
+                resources.as_file(ref)
+            )
+        return pathlib.Path(fname_or_resource)
+    else:
+        return pathlib.Path(fname_or_resource)
 
 
 def pyc_file_from_path(

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -1590,3 +1590,27 @@ class NormPathTest(TestBase):
                 Path(sd, "model3").absolute(),
             ],
         )
+
+    def test_version_locations_path_objects(self):
+        """Path objects in version_locations are normalized and matched."""
+        sd = Path(_get_staging_directory())
+        model1 = sd / "model1"
+        model2 = sd / "model2"
+        model1.mkdir()
+        model2.mkdir()
+
+        script = ScriptDirectory(
+            self.env.dir,
+            version_locations=[model1, model2],
+        )
+
+        eq_(
+            script._version_locations,
+            [model1.absolute(), model2.absolute()],
+        )
+
+        rev = script.generate_revision(
+            "12345", "test", version_path=model2
+        )
+        assert rev is not None
+        eq_(Path(rev.path).absolute().parent, model2.absolute())


### PR DESCRIPTION
Fixes #1366

Windows users with multiple version_locations have been hitting "Path ... is not represented in current version locations" when generating revisions, for example with `alembic revision --autogenerate --head "after@head" -m "my_migration"`. The original report traced this to drive-letter casing differences on Windows (`os.path.abspath("")` returning `c:\...` while `os.path.realpath("")` returns `C:\...`), and follow-up comments showed the same error appears when paths contain spaces.

The 1.16.0 release moved version-location matching to pathlib, which normalizes case and spaces correctly for string entries. But `ScriptDirectory` already accepts `os.PathLike` objects in `version_locations`, and those still pass through `coerce_resource_to_filename`, which only accepted `str` and interpreted colons as package resources. A `pathlib.Path` would therefore not normalize the same way as string entries and could fall out of the allowed-location check.

This change widens `coerce_resource_to_filename` to accept `Union[str, os.PathLike[str]]` and only runs the package-resource branch for plain strings. Path inputs now become `pathlib.Path(...)` directly and get the same `.absolute()` normalization as string entries, so drive-letter casing and spaces are handled consistently. String-based configs, including package-resource references like `my.package:versions`, keep their existing behavior.

I added a regression test to `NormPathTest` in `tests/test_script_production.py` that builds a `ScriptDirectory` from `Path` version_locations and verifies that `generate_revision` can match a `Path` version_path. I also ran `pytest tests/test_script_production.py::NormPathTest` and `mypy` on the changed module; both passed.
