### PR TITLE
Fix spurious DROP TABLE in stamp --sql to base

### DIFF
--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -639,10 +639,6 @@ class MigrationContext:
                         run_args=kw,
                     )
 
-        if self.as_sql and not head_maintainer.heads:
-            assert self.connection is not None
-            self._version.drop(self.connection)
-
     def _in_connection_transaction(self) -> bool:
         try:
             meth = self.connection.in_transaction  # type: ignore[union-attr]

--- a/docs/build/unreleased/1822.rst
+++ b/docs/build/unreleased/1822.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, commands
+    :tickets: 1822
+
+    Fixed bug where the ``stamp`` command in ``--sql`` mode would emit a
+    spurious ``DROP TABLE`` for the ``alembic_version`` table when stamping
+    down to ``base``. This DDL was never emitted for the equivalent
+    non-``--sql`` operation, which does not drop the version table; the
+    ``--sql`` output now matches that behavior. This also applies to the
+    equivalent case for ``upgrade``/``downgrade --sql``.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -977,7 +977,9 @@ class UpgradeDowngradeStampTest(TestBase):
             command.downgrade(self.cfg, "%s:base" % self.c, sql=True)
         assert "CREATE TABLE alembic_version" not in buf.getvalue()
         assert "INSERT INTO alembic_version" not in buf.getvalue()
-        assert "DROP TABLE alembic_version" in buf.getvalue()
+        # the alembic_version table is never dropped, either in --sql
+        # mode or in normal operation; see #1822
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
         assert "DROP STEP 3" in buf.getvalue()
         assert "DROP STEP 2" in buf.getvalue()
         assert "DROP STEP 1" in buf.getvalue()
@@ -1018,6 +1020,14 @@ class UpgradeDowngradeStampTest(TestBase):
             "SET version_num='%s' "
             "WHERE alembic_version.version_num = '%s';" % (self.c, self.a)
         ) in buf.getvalue()
+
+    def test_sql_stamp_to_base_no_drop(self):
+        # stamping down to "base" should never emit a DROP TABLE for
+        # alembic_version, matching the non-sql behavior which also
+        # never drops the version table; see #1822
+        with capture_context_buffer() as buf:
+            command.stamp(self.cfg, "%s:base" % self.c, sql=True)
+        assert "DROP TABLE alembic_version" not in buf.getvalue()
 
     def test_sql_stamp_from_partial_rev(self):
         with capture_context_buffer() as buf:


### PR DESCRIPTION
Fixes #1822.

`alembic stamp --sql base` emits a bare `DROP TABLE alembic_version` with no matching `CREATE TABLE` anywhere in the output. Real (non-sql) stamp never drops the version table, it only ever gets created, never dropped.

Root cause is in `MigrationContext.run_migrations()` (alembic/runtime/migration.py). At the end of the method there's an unconditional `if self.as_sql and not head_maintainer.heads: self._version.drop(...)`. This fires whenever an offline SQL script ends with zero heads, whether that's from stamp or from downgrade/upgrade steps that walk down to base. zzzeek confirmed on the issue this was a coding mistake from way back, added for --sql mode without checking that non-sql mode never does this.

Fix just removes that block so --sql output matches what actually happens against a real database.

This also changes `downgrade --sql <rev>:base` output, since it shares the same code path and had the same bug (there was an existing test, `test_version_to_none`, that was actually asserting the buggy DROP was present). Updated that test to assert no DROP, and added `test_sql_stamp_to_base_no_drop` for the stamp scenario from the issue.

Ran the full `tests/test_command.py` (116 tests) plus `test_version_traversal.py`, `test_environment.py`, `test_offline_environment.py` locally, all green.