### PR TITLE
Detect augmented JSON types when skipping batch migrate CAST

### DIFF
--- a/alembic/ddl/sqlite.py
+++ b/alembic/ddl/sqlite.py
@@ -182,9 +182,12 @@ class SQLiteImpl(DefaultImpl):
         existing_transfer: Dict[str, Union[TypeEngine, Cast]],
         new_type: TypeEngine,
     ) -> None:
+        # the JSON check uses the type affinity rather than isinstance() so
+        # that a TypeDecorator which augments JSON is also detected; CASTing
+        # to JSON in SQLite yields 0 and would destroy the data
         if (
             existing.type._type_affinity is not new_type._type_affinity
-            and not isinstance(new_type, JSON)
+            and new_type._type_affinity is not JSON
         ):
             existing_transfer["expr"] = cast(
                 existing_transfer["expr"], new_type

--- a/docs/build/unreleased/1120.rst
+++ b/docs/build/unreleased/1120.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: bug, batch migrations
+    :tickets: 1120
+
+    Fixed data loss in SQLite batch migrations when altering a column to a
+    :class:`~sqlalchemy.types.TypeDecorator` that augments
+    :class:`~sqlalchemy.types.JSON`.  The data transfer step suppresses the
+    ``CAST`` for :class:`~sqlalchemy.types.JSON`, as CASTing to ``JSON`` in
+    SQLite yields ``0``, however the check used ``isinstance()`` and therefore
+    did not match a ``TypeDecorator`` wrapping ``JSON``; every value in the
+    column was replaced with ``0``.  The check now compares type affinity, so
+    augmented types are detected as well.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -21,6 +21,7 @@ from sqlalchemy import select
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import Text
+from sqlalchemy import TypeDecorator
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects import sqlite as sqlite_dialect
 from sqlalchemy.schema import CreateIndex
@@ -1150,6 +1151,33 @@ class CopyFromTest(TestBase):
             "SELECT foo.id, "
             "CAST(foo.data AS INTEGER) AS data, foo.x, foo.toj, "
             "CAST(foo.fromj AS TEXT) AS fromj FROM foo",
+            "DROP TABLE foo",
+            "ALTER TABLE _alembic_tmp_foo RENAME TO foo",
+        )
+
+    def test_change_type_json_typedecorator(self):
+        """a TypeDecorator that augments JSON must not be CAST either.
+
+        CASTing to JSON in SQLite yields 0, so emitting the CAST here
+        would destroy the column's data.
+
+        """
+
+        class CustomJson(TypeDecorator):
+            impl = JSON
+            cache_ok = True
+
+        context = self._fixture()
+        self.table.append_column(Column("toj", Text))
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
+            batch_op.alter_column("toj", type_=CustomJson)
+        context.assert_(
+            "CREATE TABLE _alembic_tmp_foo (id INTEGER NOT NULL, "
+            "data VARCHAR(50), x INTEGER, toj JSON, PRIMARY KEY (id))",
+            "INSERT INTO _alembic_tmp_foo (id, data, x, toj) "
+            "SELECT foo.id, foo.data, foo.x, foo.toj FROM foo",
             "DROP TABLE foo",
             "ALTER TABLE _alembic_tmp_foo RENAME TO foo",
         )

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1161,6 +1161,10 @@ class CopyFromTest(TestBase):
         CASTing to JSON in SQLite yields 0, so emitting the CAST here
         would destroy the column's data.
 
+        ``_type_affinity`` resolves through any number of TypeDecorator
+        layers, so a decorator whose impl is itself a decorator over JSON
+        is covered by the same check.
+
         """
 
         class CustomJson(TypeDecorator):

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1163,7 +1163,7 @@ class CopyFromTest(TestBase):
 
         ``_type_affinity`` resolves through any number of TypeDecorator
         layers, so a decorator whose impl is itself a decorator over JSON
-        is covered by the same check.
+        is covered by the same check; both depths are asserted below.
 
         """
 
@@ -1177,6 +1177,25 @@ class CopyFromTest(TestBase):
             "foo", copy_from=self.table
         ) as batch_op:
             batch_op.alter_column("toj", type_=CustomJson)
+        context.assert_(
+            "CREATE TABLE _alembic_tmp_foo (id INTEGER NOT NULL, "
+            "data VARCHAR(50), x INTEGER, toj JSON, PRIMARY KEY (id))",
+            "INSERT INTO _alembic_tmp_foo (id, data, x, toj) "
+            "SELECT foo.id, foo.data, foo.x, foo.toj FROM foo",
+            "DROP TABLE foo",
+            "ALTER TABLE _alembic_tmp_foo RENAME TO foo",
+        )
+
+        class DoublyWrappedJson(TypeDecorator):
+            impl = CustomJson
+            cache_ok = True
+
+        context = self._fixture()
+        self.table.append_column(Column("toj", Text))
+        with self.op.batch_alter_table(
+            "foo", copy_from=self.table
+        ) as batch_op:
+            batch_op.alter_column("toj", type_=DoublyWrappedJson)
         context.assert_(
             "CREATE TABLE _alembic_tmp_foo (id INTEGER NOT NULL, "
             "data VARCHAR(50), x INTEGER, toj JSON, PRIMARY KEY (id))",


### PR DESCRIPTION
Fixes the data loss reported in #1120.

`cast_for_batch_migrate` skips the data transfer `CAST` for `JSON`, because CASTing to `JSON` in SQLite yields `0`. The check was `isinstance(new_type, JSON)`, which a `TypeDecorator` wrapping `JSON` does not satisfy, so the `CAST` went out and every value in the column became `0`.

Reproduced on an in-memory SQLite database with one row holding `{"keep": "me", "n": 123}`:

```
control, sa.JSON      value after: '{"keep": "me", "n": 123}'
                      INSERT INTO _alembic_tmp_bar (foo) SELECT bar.foo FROM bar

TypeDecorator(JSON)   value after: 0
                      INSERT INTO _alembic_tmp_bar (foo) SELECT CAST(bar.foo AS JSON) AS foo FROM bar
```

The change compares type affinity, which the condition on the line above already does:

```python
existing.type._type_affinity is not new_type._type_affinity
and new_type._type_affinity is not JSON
```

One note on the approach suggested in the issue. `isinstance(typ.dialect_impl(dialect), JSON)` does not catch this case, because for a `TypeDecorator` `dialect_impl()` returns the decorator itself rather than its impl. I measured each candidate against the SQLite dialect:

| type | `isinstance` | `dialect_impl` | `_type_affinity is JSON` |
| --- | --- | --- | --- |
| `sa.JSON()` | True | True | True |
| `TypeDecorator(impl=JSON)` | False | False | True |
| `sqlite.JSON()` | True | True | True |
| `postgresql.JSONB()` | True | True | True |
| `String`, `Integer`, `TypeDecorator(impl=String)` | False | False | False |

Affinity is the only one that catches the `TypeDecorator` while still excluding non-JSON types. `impl_instance` also works, but only for the decorator, so it would have to be combined with the existing `isinstance` check.

Worth flagging: this is a behaviour change in one narrow direction. `CAST` suppression now covers any type whose affinity is `JSON`, not only `JSON` instances, so a change from a genuinely different affinity to an augmented JSON type no longer emits the `CAST`. That is what the original guard was for, just applied to the augmented case too.

The test is `tests/test_batch.py::CopyFromTest::test_change_type_json_typedecorator`, next to `test_change_type` as suggested in the issue. It fails on main with `CAST(foo.toj AS JSON) AS toj` in the transfer statement and passes with the fix. Full suite is 1770 passed, 133 skipped, and there is a changelog fragment in `docs/build/unreleased/1120.rst`.

I used an AI assistant while working on this. The reproduction and the comparison table are things I ran myself.
