### PR TITLE
Fix batch mode ignoring naming_convention for reflected constraints

### DIFF
--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -21,6 +21,7 @@ from sqlalchemy import schema as sql_schema
 from sqlalchemy import select
 from sqlalchemy import Table
 from sqlalchemy import types as sqltypes
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.sql.schema import SchemaEventTarget
 from sqlalchemy.util import OrderedDict
 from sqlalchemy.util import topological
@@ -155,6 +156,7 @@ class BatchOperationsImpl:
                     self.table_kwargs,
                     reflected,
                     partial_reordering=self.partial_reordering,
+                    naming_convention=self.naming_convention,
                 )
                 for opname, arg, kw in self.batch:
                     fn = getattr(batch_impl, opname)
@@ -209,6 +211,43 @@ class BatchOperationsImpl:
         self.batch.append(("create_column_comment", (column,), {}))
 
 
+# Maps a constraint class to the key it uses in a SQLAlchemy
+# ``naming_convention`` dict (mirrors ``sqlalchemy.sql.naming._prefix_dict``,
+# which is private API and not something alembic imports directly).
+_NAMING_CONVENTION_PREFIXES = {
+    PrimaryKeyConstraint: "pk",
+    ForeignKeyConstraint: "fk",
+    UniqueConstraint: "uq",
+    CheckConstraint: "ck",
+}
+
+
+def _reflected_name_should_regenerate(
+    const: Constraint, naming_convention: Dict[str, str]
+) -> bool:
+    """True if a reflected (already-named) constraint's name should be
+    reset so SQLAlchemy's naming-convention machinery regenerates it
+    against the recreated table, instead of carrying over the name that
+    came back from reflection.
+
+    A reflected constraint always has an explicit ``.name`` -- it's
+    whatever is actually stored in the database -- so a
+    ``naming_convention`` passed to ``batch_alter_table()`` would
+    otherwise never take effect for it: naming conventions only fill in
+    names for *unnamed* constraints. Since the caller explicitly passed
+    a convention for this batch, we treat that as opt-in to have it
+    govern reflected constraints too, but only for constraint types the
+    convention actually has an entry for -- resetting the name of a
+    constraint type the convention says nothing about would just leave
+    it unnamed instead of regenerating it, which is worse than the
+    stale-name bug this is fixing.
+    """
+    for cls, key in _NAMING_CONVENTION_PREFIXES.items():
+        if isinstance(const, cls):
+            return key in naming_convention
+    return False
+
+
 class ApplyBatchImpl:
     def __init__(
         self,
@@ -218,6 +257,7 @@ class ApplyBatchImpl:
         table_kwargs: Dict[str, Any],
         reflected: bool,
         partial_reordering: tuple = (),
+        naming_convention: Optional[Dict[str, str]] = None,
     ) -> None:
         self.impl = impl
         self.table = table  # this is a Table object
@@ -237,6 +277,7 @@ class ApplyBatchImpl:
         self.existing_ordering = list(self.column_transfers)
 
         self.reflected = reflected
+        self.naming_convention = naming_convention
         self._grab_table_elements()
 
     @classmethod
@@ -273,7 +314,30 @@ class ApplyBatchImpl:
                 # we have no way to determine _is_type_bound() for these.
                 pass
             elif constraint_name_string(const.name):
-                self.named_constraints[const.name] = const
+                orig_name = const.name
+                if (
+                    self.reflected
+                    and self.naming_convention
+                    and _reflected_name_should_regenerate(
+                        const, self.naming_convention
+                    )
+                ):
+                    # Regenerate the name now, against self.table (which
+                    # already carries the correct *final* table name and
+                    # the naming convention) rather than deferring to
+                    # whenever this constraint gets copied onto the
+                    # temp-named recreated table -- deferring it would
+                    # bake the temporary "_alembic_tmp_<name>" table name
+                    # into the generated constraint name instead of the
+                    # real one, trading one wrong name for another.
+                    # Re-attaching re-fires SQLAlchemy's naming-convention
+                    # event, which marks the resulting name as resolved
+                    # (a `conv` instance) so it's carried over as-is when
+                    # copied onto the recreated table later, instead of
+                    # being regenerated a second time.
+                    const.name = None
+                    self.table.append_constraint(const)
+                self.named_constraints[orig_name] = const
             else:
                 self.unnamed_constraints.append(const)
 
@@ -322,7 +386,10 @@ class ApplyBatchImpl:
     def _transfer_elements_to_new_table(self) -> None:
         assert self.new_table is None, "Can only create new table once"
 
-        m = MetaData()
+        if self.naming_convention:
+            m = MetaData(naming_convention=self.naming_convention)
+        else:
+            m = MetaData()
         schema = self.table.schema
 
         if self.partial_reordering or self.add_col_ordering:

--- a/docs/build/unreleased/1834.rst
+++ b/docs/build/unreleased/1834.rst
@@ -1,0 +1,13 @@
+.. change::
+    :tags: bug, batch
+    :tickets: 1834
+
+    Fixed bug in batch mode where a ``naming_convention`` passed to
+    ``batch_alter_table()`` was not applied to constraints that came back
+    from reflection, only to newly added ones. Since a reflected
+    constraint always has an explicit name (whatever is stored in the
+    database), a naming convention -- which only fills in names for
+    *unnamed* constraints -- silently had no effect on it. This was most
+    visible after ``rename_table()``: a recreated table's constraints
+    would carry over names embedding the *old* table name instead of
+    being renamed to match the convention against the new one.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1820,6 +1820,57 @@ class BatchRoundTripTest(TestBase):
             batch_op.drop_constraint("fk_bar_foo_id_foo", type_="foreignkey")
         eq_(inspect(self.conn).get_foreign_keys("bar"), [])
 
+    def test_naming_convention_applies_to_reflected_constraints(self):
+        """A naming_convention passed to batch_alter_table() should govern
+        constraints that come back from reflection too, not just newly
+        added ones -- notably, after rename_table(), a recreated table's
+        constraints should be named against the *new* table name rather
+        than carrying over the name reflection reported for the old one.
+        """
+        naming_convention = {
+            "pk": "pk_%(table_name)s",
+            "fk": (
+                "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s"
+            ),
+        }
+        md = MetaData(naming_convention=naming_convention)
+        Table("other", md, Column("name", String(50), primary_key=True))
+        Table(
+            "oldtablename",
+            md,
+            Column("col", String(50), primary_key=True),
+            ForeignKeyConstraint(["col"], ["other.name"], ondelete="CASCADE"),
+        )
+        with self.conn.begin():
+            md.create_all(self.conn)
+
+        try:
+            self.op.rename_table("oldtablename", "tablename")
+            with self.op.batch_alter_table(
+                "tablename",
+                naming_convention=naming_convention,
+                recreate="always",
+            ) as batch_op:
+                batch_op.alter_column("col", existing_type=String(50))
+
+            pk = inspect(self.conn).get_pk_constraint("tablename")
+            eq_(pk["name"], "pk_tablename")
+
+            fks = inspect(self.conn).get_foreign_keys("tablename")
+            eq_(len(fks), 1)
+            eq_(fks[0]["name"], "fk_tablename_col_other")
+        finally:
+            # see tearDown()'s comment on why a commit is needed here on
+            # SQLite before the connection can be used for further DDL.
+            _safe_commit_connection_transaction(self.conn)
+            with self.conn.begin():
+                # the table was renamed and recreated since `old`/`other`
+                # were defined, so reflect current state before dropping
+                # rather than relying on the (now stale) Table objects.
+                m = MetaData()
+                m.reflect(self.conn)
+                m.drop_all(self.conn)
+
     def test_drop_column_fk_recreate(self):
         with self.op.batch_alter_table("foo", recreate="always") as batch_op:
             batch_op.drop_column("data")


### PR DESCRIPTION
Fixes: #1834

### Description

`batch_alter_table(..., naming_convention=...)` reflects the existing table into a `MetaData(naming_convention=...)`, clearly intending for the convention to govern the recreated table's constraint names. But reflection always returns constraints with an explicit `.name` (whatever is actually stored in the database), and SQLAlchemy naming conventions only fill in names for constraints that don't already have one — so the convention silently had no effect on any reflected constraint.

This was most visible after `rename_table()`: batch mode would faithfully carry over reflected constraint names that still embed the *old* table name (e.g. `pk_OldTableName` after renaming to `TableName`), even though a `naming_convention` was explicitly passed to make names track the current table.

### Fix

In `ApplyBatchImpl._grab_table_elements()`, a reflected constraint whose type has an entry in the supplied `naming_convention` (pk/fk/uq/ck) now has its name reset to `None` and is re-attached to `self.table` — which already carries the correct, final table name and the convention — so SQLAlchemy's own naming-convention event recomputes the name against the right target immediately, before the constraint gets copied onto the temp-named table used internally during the "move and copy". (An earlier version of this fix deferred the regeneration to copy time instead, which "fixed" the stale-old-name bug but introduced a different one — baking `_alembic_tmp_<name>` into the constraint name. Caught via a test that isolates the no-rename case and fixed by regenerating against `self.table` up front.)

Constraint types the convention doesn't mention are left untouched, so this can't turn some other constraint into an unnamed one it wasn't asked to govern.

`_transfer_elements_to_new_table()` now also carries `naming_convention` onto the new table's `MetaData` (previously always plain `MetaData()`), which the reset-name mechanism above relies on.

### Checklist

- [x] A short code fix
- Issue: #1834 (includes a complete reproduction and root-cause diagnosis)
- `Fixes: #1834` included above
- Tests: `tests/test_batch.py::BatchRoundTripTest::test_naming_convention_applies_to_reflected_constraints` — reproduces the issue's exact scenario (rename + batch recreate with a naming_convention covering pk/fk), asserts the recreated table's PK and FK names track the *new* table name. Verified this test fails against unpatched `main` with the exact bug signature (`pk_oldtablename != pk_tablename`).

### Test plan

- New regression test passes; fails on unpatched `main` with the issue's exact symptom.
- Full suite: `pytest tests/` → 1799 passed, 132 skipped (pre-existing, dialect-specific), 0 failed.
- `black --check` / `flake8` clean on both changed files.
- Changelog fragment added at `docs/build/unreleased/1834.rst`.