### PR TITLE
test: add coverage for alternate version_path spellings

### DIFF
--- a/docs/build/unreleased/1366.rst
+++ b/docs/build/unreleased/1366.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, tests
+    :tickets: 1366
+
+    Added test coverage asserting that a ``--version-path`` naming an already
+    configured version location is accepted however it is spelled, covering a
+    trailing path separator and, on Windows, the case of the drive letter. The
+    matching moved to ``pathlib`` in 1.16.0, which resolved the behaviour
+    reported in :ticket:`1366`; this pins it so it cannot regress.

--- a/docs/build/unreleased/1366.rst
+++ b/docs/build/unreleased/1366.rst
@@ -1,9 +1,0 @@
-.. change::
-    :tags: bug, tests
-    :tickets: 1366
-
-    Added test coverage asserting that a ``--version-path`` naming an already
-    configured version location is accepted however it is spelled, covering a
-    trailing path separator and, on Windows, the case of the drive letter. The
-    matching moved to ``pathlib`` in 1.16.0, which resolved the behaviour
-    reported in :ticket:`1366`; this pins it so it cannot regress.

--- a/tests/test_script_production.py
+++ b/tests/test_script_production.py
@@ -1377,6 +1377,29 @@ class MultiDirRevisionCommandTest(TestBase):
         )
         assert os.access(script.path, os.F_OK)
 
+    def test_multiple_dir_no_bases_version_path_alternate_spelling(self):
+        """Spellings that name the same directory must all be accepted.
+
+        A trailing separator is tested everywhere; on Windows the drive
+        letter's case is tested too, which is what was reported.
+        """
+        configured = os.path.join(_get_staging_directory(), "model1")
+
+        spellings = [configured + os.sep]
+        drive, rest = os.path.splitdrive(os.path.abspath(configured))
+        if drive:
+            spellings.append(drive.swapcase() + rest)
+
+        for spelling in spellings:
+            script = command.revision(
+                self.cfg, message="x", head="base", version_path=spelling
+            )
+            assert os.access(script.path, os.F_OK)
+            eq_(
+                Path(script.path).parent.absolute(),
+                Path(configured).absolute(),
+            )
+
     def test_multiple_dir_chooses_base(self):
         command.revision(
             self.cfg,


### PR DESCRIPTION
Closes https://github.com/sqlalchemy/alembic/issues/1366

@zzzeek asked on the issue for this to be *"confirmed as fixed and maybe even a test added to confirm it"* — this does both. I'm on Windows 11, so I could exercise the reported paths directly rather than reason about them.

## Confirmed fixed

Built a multi-head project whose version locations contain spaces, seeded a head in each, then created a revision naming the same directory five different ways. On **1.19.2**:

| spelling of `--version-path` | result |
|---|---|
| exactly as configured | accepted |
| lower-case drive letter (`c:\…`) | accepted |
| upper-case drive letter (`C:\…`) | accepted |
| trailing separator | accepted |
| spaces anywhere in the path | accepted |

So the original report — drive-letter capitalisation — is genuinely resolved by the move to `pathlib`, exactly as you expected. `PureWindowsPath.__eq__` is case-insensitive, so `.absolute() == .absolute()` handles it.

## The test

Nothing pinned that. `MultiDirRevisionCommandTest` gains one test asserting a revision lands in the configured directory when the path carries a trailing separator, and — where a drive letter exists — when its case is swapped. It is written to be portable rather than skipped: `os.path.splitdrive` returns an empty drive on POSIX, so only the trailing-separator spelling runs there.

To check it has teeth, I replaced the case-insensitive `Path` comparison in `generate_revision()` with a string comparison:

```
-            if vers_path.absolute() == norm_path:
+            if str(vers_path.absolute()) == str(norm_path):
```

**Only the new test fails**; the four existing tests in that class still pass. Reverting the whole comparison to raw strings fails the new test plus two existing ones. So it covers ground the suite did not.

## Two spellings that still fail — deliberately not changed here

While testing I found the same error is still raised for two other spellings of a configured directory:

- a path routed through `..` — `…\migrations\zzz\..\versions before`
- the 8.3 short name — `C:\…\Temp\ALEMBI~3\MYPROJ~1\MIGRAT~1\VERSIO~1`

Both are the same cause: `Path.absolute()` normalises neither, while `Path.resolve()` handles both (verified directly). I have **not** touched that, because switching to `resolve()` also starts following symlinks, which is a behaviour decision for you rather than something to slip into a test PR. Happy to open a separate issue or PR if you want it changed.

## On the "spaces" reports in this thread

@Tayyab-H and @SalamM1 reported failures whenever the path contained spaces, which didn't match what I measured. It reproduces exactly when `path_separator` is absent from the config: alembic then falls back to legacy splitting on **spaces and commas**, which cuts any path containing a space in half. Same project, same path, only that key differing:

```
path_separator = os    -> revision created
(key removed)          -> FAILED: Path C:\...\my project\migrations\versions before
                          is not represented in current version locations
```

A `DeprecationWarning` is emitted, but `DeprecationWarning` is hidden by default outside `__main__`, so it never reaches the user and they see only the confusing path error. `alembic init` has written `path_separator = os` since 1.16.0, so this only affects configs predating that. That may be worth its own issue — say the word and I'll file it rather than widen this PR.

## Testing

Windows 11, Python 3.13, alembic 1.19.2, SQLAlchemy 2.0.51.

- `pytest tests/` — **1814 passed, 5 failed, 132 skipped**. The 5 failures are all `ScriptNamingTest` timezone tests failing on a clean `main` checkout too (`zoneinfo` has no system tzdata on Windows); identical before and after this change, verified by stashing it and re-running. No new failures.
- `tests/test_script_production.py` alone: 39 passed on clean `main`, 40 with this change — same 5 pre-existing failures.
- `black --check`, `flake8` and `zimports --diff` are clean on the changed file.
- I could not run the Linux or macOS jobs locally; the new test's POSIX path is the trailing-separator spelling only, and CI is the authority there.
