### PR TITLE
Fix: In ApplyBatchImpl.flush() (alembic/operations/batch.py), when...

### DIFF
--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -143,6 +143,58 @@ class BatchOperationsImpl:
                     )
                     reflected = True
 
+                    if self.naming_convention:
+                        # reflected constraints already have a real,
+                        # persisted name.  however, a naming convention
+                        # such as {"ck": "ck_%(table_name)s_%(constraint_name)s"}  # noqa: E501
+                        # gets re-applied to that name during the above
+                        # reflection since the constraint's name is not
+                        # distinguished from a freshly-assigned one,
+                        # causing it to be prefixed a second time.
+                        # reflect again into a plain MetaData() (no
+                        # naming convention) to determine each
+                        # constraint's real, un-mangled name, and
+                        # restore it.  constraints that are genuinely
+                        # unnamed in the database are left alone so the
+                        # naming convention can still generate a name
+                        # for them.
+                        plain_table = Table(
+                            self.table_name,
+                            MetaData(),
+                            schema=self.schema,
+                            autoload_with=self.operations.get_bind(),
+                            *self.reflect_args,
+                            **self.reflect_kwargs,
+                        )
+                        plain_names = {
+                            (
+                                type(const),
+                                tuple(
+                                    col.name
+                                    for col in _columns_for_constraint(
+                                        const
+                                    )
+                                ),
+                            ): const.name
+                            for const in plain_table.constraints
+                            if not _is_type_bound(const)
+                        }
+                        for const in existing_table.constraints:
+                            if _is_type_bound(const):
+                                continue
+                            key = (
+                                type(const),
+                                tuple(
+                                    col.name
+                                    for col in _columns_for_constraint(
+                                        const
+                                    )
+                                ),
+                            )
+                            real_name = plain_names.get(key)
+                            if real_name:
+                                const.name = real_name
+
                 batch_impl = ApplyBatchImpl(
                     self.impl,
                     existing_table,

--- a/docs/build/unreleased/1845.rst
+++ b/docs/build/unreleased/1845.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, batch
+    :tickets: 1845
+
+    Fixed issue in batch mode where a ``naming_convention`` passed to
+    :meth:`.Operations.batch_alter_table` that included the
+    ``%(constraint_name)s`` token, such as a ``"ck"`` convention, would be
+    re-applied to already-named constraints reflected from the existing
+    table during a batch "recreate" operation, causing the constraint's
+    name to be prefixed a second time.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1820,6 +1820,63 @@ class BatchRoundTripTest(TestBase):
             batch_op.drop_constraint("fk_bar_foo_id_foo", type_="foreignkey")
         eq_(inspect(self.conn).get_foreign_keys("bar"), [])
 
+    @config.requirements.check_constraint_reflection
+    def test_naming_convention_ck_preserves_reflected_name(self):
+        """test #1845.
+
+        a naming convention that contains %(constraint_name)s must not
+        be re-applied to a check constraint that already has a name
+        from reflection, else the name gets prefixed a second time.
+
+        """
+        self._ck_constraint_fixture()
+
+        naming_convention = {
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+        }
+        with self.op.batch_alter_table(
+            "ck_table",
+            recreate="always",
+            naming_convention=naming_convention,
+        ) as batch_op:
+            batch_op.add_column(Column("x", Integer))
+
+        ck_consts = inspect(self.conn).get_check_constraints("ck_table")
+        for ck in ck_consts:
+            ck.pop("comment", None)
+        eq_(ck_consts, [{"sqltext": "id is not NULL", "name": "ck"}])
+
+    @config.requirements.check_constraint_reflection
+    def test_naming_convention_ck_applies_to_new_unnamed(self):
+        """test #1845 counterpart: naming convention should still
+
+        generate a name for a genuinely new, unnamed constraint added
+        during the same batch operation.
+
+        """
+        self._ck_constraint_fixture()
+
+        naming_convention = {
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+        }
+        with self.op.batch_alter_table(
+            "ck_table",
+            recreate="always",
+            naming_convention=naming_convention,
+        ) as batch_op:
+            batch_op.create_check_constraint("newck", text("id > 0"))
+
+        ck_consts = inspect(self.conn).get_check_constraints("ck_table")
+        for ck in ck_consts:
+            ck.pop("comment", None)
+        eq_(
+            sorted(ck_consts, key=lambda d: d["name"]),
+            [
+                {"sqltext": "id is not NULL", "name": "ck"},
+                {"sqltext": "id > 0", "name": "newck"},
+            ],
+        )
+
     def test_drop_column_fk_recreate(self):
         with self.op.batch_alter_table("foo", recreate="always") as batch_op:
             batch_op.drop_column("data")


### PR DESCRIPTION
## Summary
After reflecting the existing table into the naming_convention-bearing MetaData (m1) as before (this reflection is still needed so genuinely unnamed constraints -- e.g. some unnamed FKs on SQLite -- still get a convention-generated name, matching existing test_drop_foreign_key behavior), the table is reflected a second time into a plain MetaData() with no naming_convention. This second reflection yields each constraint's true, un-mangled database name. Constraints from the first (convention-bearing) reflection are then matched to their plain-reflected counterpart by (type, column names) and, when the plain-reflected constraint already had a real name, that true name is restored onto the convention-reflected constraint, undoing any double-prefixing. Constraints with no name in the plain reflection are left untouched so the convention can still generate a name for them.

## Problem
sqlalchemy/alembic issue reference: sqlalchemy/alembic#1845

## Root Cause
In ApplyBatchImpl.flush() (alembic/operations/batch.py), when should_recreate is True the existing table is reflected via Table(..., autoload_with=...) into a MetaData(naming_convention=self.naming_convention). SQLAlchemy's naming convention machinery re-applies the %(constraint_name)s token substitution to a constraint's name even when it was reflected and already has a real, persisted name -- it does not distinguish 'freshly reflected, already named' from 'newly created, needs a generated name'. This is only user-visible for convention templates that include %(constraint_name)s (e.g. 'ck'); uq/fk/pk templates in the repo's own tests don't use that token so they weren't previously affected.

## Testing
PASS - full tests/test_batch.py suite: 120 passed, 7 skipped (skips are pre-existing, backend-specific), including the two new regression tests and the pre-existing naming_convention test_drop_foreign_key (fk convention with %(column_0_name)s etc., unaffected/still passing).

## Related Issue
sqlalchemy/alembic#1845
