### PR TITLE
Fix: In BatchOperationsImpl.flush() (alembic/operations/batch.py), the...

### DIFF
--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -149,6 +149,7 @@ class BatchOperationsImpl:
                     self.table_args,
                     self.table_kwargs,
                     reflected,
+                    naming_convention=self.naming_convention,
                     partial_reordering=self.partial_reordering,
                 )
                 for opname, arg, kw in self.batch:
@@ -212,12 +213,14 @@ class ApplyBatchImpl:
         table_args: tuple,
         table_kwargs: dict[str, Any],
         reflected: bool,
+        naming_convention: dict[str, str] | None = None,
         partial_reordering: tuple = (),
     ) -> None:
         self.impl = impl
         self.table = table  # this is a Table object
         self.table_args = table_args
         self.table_kwargs = table_kwargs
+        self.naming_convention = naming_convention
         self.temp_table_name = self._calc_temp_name(table.name)
         self.new_table: Table | None = None
 
@@ -317,7 +320,10 @@ class ApplyBatchImpl:
     def _transfer_elements_to_new_table(self) -> None:
         assert self.new_table is None, "Can only create new table once"
 
-        m = MetaData()
+        if self.naming_convention:
+            m = MetaData(naming_convention=self.naming_convention)
+        else:
+            m = MetaData()
         schema = self.table.schema
 
         if self.partial_reordering or self.add_col_ordering:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1223,6 +1223,34 @@ class CopyFromTest(TestBase):
             "ALTER TABLE _alembic_tmp_foo RENAME TO foo",
         )
 
+    def test_change_type_to_schematype_w_naming_convention(self):
+        """test #1844"""
+        context = self._fixture()
+        self.table.append_column(Column("y", Integer))
+
+        naming_convention = {
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+        }
+        with self.op.batch_alter_table(
+            "foo",
+            copy_from=self.table,
+            naming_convention=naming_convention,
+        ) as batch_op:
+            batch_op.alter_column(
+                "y",
+                existing_type=Integer,
+                type_=Boolean(create_constraint=True, name="ck1"),
+            )
+        context.assert_(
+            "CREATE TABLE _alembic_tmp_foo (id INTEGER NOT NULL, "
+            "data VARCHAR(50), x INTEGER, y BOOLEAN, PRIMARY KEY (id), "
+            "CONSTRAINT ck__alembic_tmp_foo_ck1 CHECK (y IN (0, 1)))",
+            "INSERT INTO _alembic_tmp_foo (id, data, x, y) SELECT foo.id, "
+            "foo.data, foo.x, CAST(foo.y AS BOOLEAN) AS y FROM foo",
+            "DROP TABLE foo",
+            "ALTER TABLE _alembic_tmp_foo RENAME TO foo",
+        )
+
     def test_create_drop_index_w_always(self):
         context = self._fixture()
         with self.op.batch_alter_table(


### PR DESCRIPTION
## Summary
Added a `naming_convention` parameter to ApplyBatchImpl.__init__, stored as self.naming_convention. Updated _transfer_elements_to_new_table() to build the temp table's MetaData with `MetaData(naming_convention=self.naming_convention)` when set, matching the pattern already used for m1 in flush(). Updated BatchOperationsImpl.flush() to pass self.naming_convention through when constructing ApplyBatchImpl.

## Problem
sqlalchemy/alembic issue reference: sqlalchemy/alembic#1844

## Root Cause
In BatchOperationsImpl.flush() (alembic/operations/batch.py), the copy_from branch reuses the caller's Table object verbatim (its own MetaData, no naming_convention) as expected. However, the actual constraint materialization for SchemaType-generated CHECK constraints happens later in ApplyBatchImpl._transfer_elements_to_new_table(), which builds the temp table on `m = MetaData()` -- a brand new MetaData with no naming_convention, regardless of what convention was passed to batch_alter_table(). Boolean/Enum(create_constraint=True) columns regenerate their CheckConstraint when attached to this temp table, and that regeneration resolves its name via the temp table's MetaData.naming_convention -- which was always empty. This affects both the copy_from and reflected paths (both funnel through the same temp-table construction), but is specifically what the issue describes for copy_from.

## Testing
PASS - full tests/test_batch.py suite: 119 passed, 7 skipped (unrelated DB-specific skips), 0 failures, including the new regression test and all pre-existing naming-convention/CopyFromTest tests.

## Related Issue
sqlalchemy/alembic#1844
