### PR TITLE
feat(autogenerate): support compare_computed option to detect computed column changes

### DIFF
--- a/alembic/autogenerate/compare/server_defaults.py
+++ b/alembic/autogenerate/compare/server_defaults.py
@@ -71,45 +71,111 @@ def _compare_computed_default(
     if conn_col_default is None and metadata_default is None:
         return PriorityDispatchResult.CONTINUE
 
-    if sqla_compat._server_default_is_computed(
+    is_conn_computed = sqla_compat._server_default_is_computed(
         conn_col_default
-    ) and not sqla_compat._server_default_is_computed(metadata_default):
-        _warn_computed_not_supported(tname, cname)
-        return PriorityDispatchResult.STOP
+    )
+    is_meta_computed = sqla_compat._server_default_is_computed(
+        metadata_default
+    )
 
-    if not sqla_compat._server_default_is_computed(metadata_default):
+    if not is_conn_computed and not is_meta_computed:
         return PriorityDispatchResult.CONTINUE
 
-    rendered_metadata_default = str(
-        cast(sa_schema.Computed, metadata_col.server_default).sqltext.compile(
-            dialect=autogen_context.dialect,
-            compile_kwargs={"literal_binds": True},
-        )
-    )
+    migration_context = autogen_context.migration_context
+    user_compare_computed = migration_context._user_compare_computed
 
-    # since we cannot change computed columns, we do only a crude comparison
-    # here where we try to eliminate syntactical differences in order to
-    # get a minimal comparison just to emit a warning.
+    if user_compare_computed is False:
+        if is_conn_computed and not is_meta_computed:
+            _warn_computed_not_supported(tname, cname)
+        elif is_meta_computed:
+            rendered_metadata = str(
+                cast(sa_schema.Computed, metadata_default).sqltext.compile(
+                    dialect=autogen_context.dialect,
+                    compile_kwargs={"literal_binds": True},
+                )
+            )
+            rendered_metadata = _normalize_computed_default(rendered_metadata)
 
-    rendered_metadata_default = _normalize_computed_default(
-        rendered_metadata_default
-    )
+            if is_conn_computed:
+                rendered_conn = str(
+                    cast(sa_schema.Computed, conn_col_default).sqltext.compile(
+                        dialect=autogen_context.dialect,
+                        compile_kwargs={"literal_binds": True},
+                    )
+                )
+                rendered_conn = _normalize_computed_default(rendered_conn)
+            else:
+                rendered_conn = ""
 
-    if isinstance(conn_col.server_default, sa_schema.Computed):
-        rendered_conn_default = str(
-            conn_col.server_default.sqltext.compile(
+            if rendered_metadata != rendered_conn:
+                _warn_computed_not_supported(tname, cname)
+
+        return PriorityDispatchResult.STOP
+
+    alter_column_op.existing_server_default = conn_col_default
+
+    rendered_metadata_computed = (
+        str(
+            cast(sa_schema.Computed, metadata_default).sqltext.compile(
                 dialect=autogen_context.dialect,
                 compile_kwargs={"literal_binds": True},
             )
         )
-        rendered_conn_default = _normalize_computed_default(
-            rendered_conn_default
-        )
-    else:
-        rendered_conn_default = ""
+        if is_meta_computed
+        else None
+    )
 
-    if rendered_metadata_default != rendered_conn_default:
-        _warn_computed_not_supported(tname, cname)
+    rendered_conn_computed = (
+        str(
+            cast(sa_schema.Computed, conn_col_default).sqltext.compile(
+                dialect=autogen_context.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        if is_conn_computed
+        else None
+    )
+
+    if callable(user_compare_computed):
+        is_diff = user_compare_computed(
+            migration_context,
+            conn_col,
+            metadata_col,
+            conn_col_default if is_conn_computed else None,
+            metadata_default if is_meta_computed else None,
+            rendered_metadata_computed,
+        )
+        if is_diff:
+            alter_column_op.modify_server_default = metadata_default
+            log.info(
+                "User defined function %s detected "
+                "computed default on column '%s.%s'",
+                user_compare_computed,
+                tname,
+                cname,
+            )
+            return PriorityDispatchResult.STOP
+        elif is_diff is False:
+            return PriorityDispatchResult.STOP
+
+    norm_meta = (
+        _normalize_computed_default(rendered_metadata_computed)
+        if rendered_metadata_computed
+        else ""
+    )
+    norm_conn = (
+        _normalize_computed_default(rendered_conn_computed)
+        if rendered_conn_computed
+        else ""
+    )
+
+    if norm_meta != norm_conn:
+        alter_column_op.modify_server_default = metadata_default
+        log.info(
+            "Detected computed default change on column '%s.%s'",
+            tname,
+            cname,
+        )
 
     return PriorityDispatchResult.STOP
 
@@ -188,6 +254,11 @@ def _user_compare_server_default(
     metadata_default = metadata_col.server_default
     conn_col_default = conn_col.server_default
     if conn_col_default is None and metadata_default is None:
+        return PriorityDispatchResult.CONTINUE
+
+    if sqla_compat._server_default_is_computed(
+        conn_col_default
+    ) or sqla_compat._server_default_is_computed(metadata_default):
         return PriorityDispatchResult.CONTINUE
 
     alter_column_op.existing_server_default = conn_col_default

--- a/alembic/runtime/environment.py
+++ b/alembic/runtime/environment.py
@@ -431,6 +431,7 @@ class EnvironmentContext(util.ModuleClsProxy):
         ) = None,
         compare_type: bool | CompareType = True,
         compare_server_default: bool | CompareServerDefault = False,
+        compare_computed: bool | CompareServerDefault = False,
         render_item: RenderItemFn | None = None,
         literal_binds: bool = False,
         upgrade_token: str = "upgrades",
@@ -627,6 +628,44 @@ class EnvironmentContext(util.ModuleClsProxy):
          .. seealso::
 
             :paramref:`.EnvironmentContext.configure.compare_type`
+
+        :param compare_computed: Indicates computed column expression comparison
+         behavior during
+         an autogenerate operation.  Defaults to ``False`` which disables
+         computed column expression
+         comparison.  Set to ``True`` to turn on computed column expression comparison,
+         which will emit a migration when a computed column's SQL expression changes.
+         Since most databases do not support altering a computed column expression in-place,
+         the migration will typically drop and re-add the column.
+
+         To customize computed column expression comparison behavior, a callable may
+         be specified which can filter computed column comparisons during an
+         autogenerate operation. The format of this callable is::
+
+            def my_compare_computed(context, inspected_column,
+                        metadata_column, inspected_computed, metadata_computed,
+                        rendered_metadata_computed):
+                # return True if the computed expressions are different,
+                # False if not, or None to allow the default implementation
+                # to compare these expressions
+                return None
+
+            context.configure(
+                # ...
+                compare_computed = my_compare_computed
+            )
+
+         ``inspected_column`` is a dictionary structure as returned by
+         :meth:`sqlalchemy.engine.reflection.Inspector.get_columns`, whereas
+         ``metadata_column`` is a :class:`sqlalchemy.schema.Column` from
+         the local model environment.
+
+         A return value of ``None`` indicates to allow default computed column
+         comparison to proceed.
+
+         .. seealso::
+
+            :paramref:`.EnvironmentContext.configure.compare_server_default`
 
         :param include_name: A callable function which is given
          the chance to return ``True`` or ``False`` for any database reflected
@@ -929,6 +968,8 @@ class EnvironmentContext(util.ModuleClsProxy):
         opts["compare_type"] = compare_type
         if compare_server_default is not None:
             opts["compare_server_default"] = compare_server_default
+        if compare_computed is not None:
+            opts["compare_computed"] = compare_computed
         opts["script"] = self.script
 
         opts.update(kw)

--- a/alembic/runtime/migration.py
+++ b/alembic/runtime/migration.py
@@ -179,6 +179,7 @@ class MigrationContext:
         self._user_compare_server_default = opts.get(
             "compare_server_default", False
         )
+        self._user_compare_computed = opts.get("compare_computed", False)
         self.version_table = version_table = opts.get(
             "version_table", "alembic_version"
         )

--- a/tests/test_autogen_diffs.py
+++ b/tests/test_autogen_diffs.py
@@ -4,6 +4,7 @@ from sqlalchemy import Boolean
 from sqlalchemy import CHAR
 from sqlalchemy import CheckConstraint
 from sqlalchemy import Column
+from sqlalchemy import Computed
 from sqlalchemy import DATE
 from sqlalchemy import DateTime
 from sqlalchemy import DECIMAL
@@ -934,6 +935,135 @@ class CompareServerDefaultTest(TestBase):
         mc = MigrationContext.configure(
             connection,
             opts={"compare_server_default": my_compare_server_default},
+        )
+
+        diff = api.compare_metadata(mc, new_metadata)
+        if expect_diff:
+            eq_(len(diff), 1)
+            eq_(diff[0][0][0], "modify_default")
+        else:
+            assert not diff
+
+
+class CompareComputedDefaultTest(TestBase):
+    __backend__ = True
+    __requires__ = ("computed_columns",)
+
+    def test_compare_computed_disabled(self, connection, metadata):
+        t1 = Table(
+            "t1",
+            metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 1")),
+        )
+        t1.create(connection)
+
+        new_metadata = MetaData()
+        Table(
+            "t1",
+            new_metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 2")),
+        )
+
+        mc = MigrationContext.configure(
+            connection,
+            opts={"compare_computed": False},
+        )
+
+        diff = api.compare_metadata(mc, new_metadata)
+        assert not diff
+
+    def test_compare_computed_enabled_diff(self, connection, metadata):
+        t1 = Table(
+            "t1",
+            metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 1")),
+        )
+        t1.create(connection)
+
+        new_metadata = MetaData()
+        Table(
+            "t1",
+            new_metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 2")),
+        )
+
+        mc = MigrationContext.configure(
+            connection,
+            opts={"compare_computed": True},
+        )
+
+        diff = api.compare_metadata(mc, new_metadata)
+        eq_(len(diff), 1)
+        eq_(diff[0][0][0], "modify_default")
+
+    def test_compare_computed_enabled_no_diff(self, connection, metadata):
+        t1 = Table(
+            "t1",
+            metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 1")),
+        )
+        t1.create(connection)
+
+        new_metadata = MetaData()
+        Table(
+            "t1",
+            new_metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 1")),
+        )
+
+        mc = MigrationContext.configure(
+            connection,
+            opts={"compare_computed": True},
+        )
+
+        diff = api.compare_metadata(mc, new_metadata)
+        assert not diff
+
+    @testing.combinations(
+        (False, "x + 2", False),
+        (True, "x + 1", True),
+        (None, "x + 2", True),
+        id_="naa",
+        argnames="return_value,new_expr,expect_diff",
+    )
+    def test_user_compare_computed_return_values(
+        self, return_value, new_expr, expect_diff, connection, metadata
+    ):
+        def my_compare_computed(
+            context,
+            inspected_col,
+            metadata_col,
+            inspected_computed,
+            metadata_computed,
+            rendered_metadata_computed,
+        ):
+            return return_value
+
+        t1 = Table(
+            "t1",
+            metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed("x + 1")),
+        )
+        t1.create(connection)
+
+        new_metadata = MetaData()
+        Table(
+            "t1",
+            new_metadata,
+            Column("x", Integer),
+            Column("y", Integer, Computed(new_expr)),
+        )
+
+        mc = MigrationContext.configure(
+            connection,
+            opts={"compare_computed": my_compare_computed},
         )
 
         diff = api.compare_metadata(mc, new_metadata)


### PR DESCRIPTION
### Description
This PR implements computed column expression comparison logic in Alembic's autogenerate engine, supporting the `compare_computed` option.

When `compare_computed` is set to `True` (or a custom filter function returning `True` or `None`), autogenerate detects when a `Computed` column expression has changed and emits a `modify_default` operation on `AlterColumnOp`.

When `compare_computed` is `False` (default), existing behavior is maintained where a warning is emitted if computed expressions differ.

Fixes: #1837
