### PR TITLE
Fix BatchOperations.create_index typing

### DIFF
--- a/alembic/operations/base.py
+++ b/alembic/operations/base.py
@@ -1857,7 +1857,10 @@ class BatchOperations(AbstractOperations):
             ...
 
         def create_index(
-            self, index_name: str, columns: list[str], **kw: Any
+            self,
+            index_name: str,
+            columns: Sequence[str | TextClause | ColumnElement[Any]],
+            **kw: Any,
         ) -> None:
             """Issue a "create index" instruction using the
             current batch migration context.

--- a/alembic/operations/ops.py
+++ b/alembic/operations/ops.py
@@ -1008,7 +1008,7 @@ class CreateIndexOp(MigrateOperation):
         cls,
         operations: BatchOperations,
         index_name: str,
-        columns: list[str],
+        columns: Sequence[str | TextClause | ColumnElement[Any]],
         **kw: Any,
     ) -> None:
         """Issue a "create index" instruction using the


### PR DESCRIPTION
Fixes: #1853

### Description

Update `BatchOperations.create_index()` so its generated API accepts the same column expression types as `Operations.create_index()`. This removes false type-checker errors for batch migrations that use expressions such as `literal_column()`.

The `BatchOperations` API was regenerated with `tools/write_pyi.py`. Generated-stub consistency, the repository mypy check, and the SQLite test suite pass.