### PR TITLE
Warn when batch recreate skips unnamed reflected CHECK constraints

### DIFF
--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -20,6 +20,7 @@ from sqlalchemy.sql.schema import SchemaEventTarget
 from sqlalchemy.util import OrderedDict
 from sqlalchemy.util import topological
 
+from .. import util
 from ..util import exc
 from ..util.sqla_compat import _columns_for_constraint
 from ..util.sqla_compat import _copy
@@ -263,10 +264,17 @@ class ApplyBatchImpl:
                 and isinstance(const, CheckConstraint)
                 and not const.name
             ):
-                # TODO: we are skipping unnamed reflected CheckConstraint
-                # because
-                # we have no way to determine _is_type_bound() for these.
-                pass
+                # Unnamed reflected CHECKs cannot be distinguished from
+                # type-bound constraints, so they are not recreated. Warn
+                # rather than dropping them silently.
+                sqltext = getattr(const, "sqltext", None)
+                detail = f" ({sqltext})" if sqltext is not None else ""
+                util.warn(
+                    "Skipping unnamed CHECK constraint on reflected "
+                    "table %r during batch recreate%s. Name the "
+                    "constraint, or restate it via table_args, if it "
+                    "should be preserved." % (self.table.name, detail)
+                )
             elif constraint_name_string(const.name):
                 self.named_constraints[const.name] = const
             else:

--- a/docs/build/unreleased/unnamed_check_skip_warn.rst
+++ b/docs/build/unreleased/unnamed_check_skip_warn.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, operations
+    :tickets: 1846
+
+    Batch table recreate now emits a :class:`python:UserWarning` when an
+    unnamed CHECK constraint on a reflected table is skipped, instead of
+    dropping it silently.  Name the constraint, or restate it via
+    ``table_args``, if it should be preserved.  Pull request courtesy
+    Burak Keskin.

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -41,6 +41,7 @@ from alembic.testing import config
 from alembic.testing import eq_
 from alembic.testing import exclusions
 from alembic.testing import expect_raises_message
+from alembic.testing import expect_warnings
 from alembic.testing import is_
 from alembic.testing import mock
 from alembic.testing import TestBase
@@ -813,6 +814,31 @@ class BatchApplyTest(TestBase):
             impl,
             colnames=["id", "x", "y"],
             ddl_not_contains="CONSTRAINT uq1 UNIQUE",
+        )
+
+    def test_reflected_unnamed_ck_warns(self):
+        """test for #1846"""
+        m = MetaData()
+        t = Table(
+            "tname",
+            m,
+            Column("id", Integer, primary_key=True),
+            Column("x", Integer),
+            CheckConstraint("x > 5"),
+        )
+        with expect_warnings(
+            "Skipping unnamed CHECK constraint on reflected table 'tname'"
+        ):
+            impl = ApplyBatchImpl(self.impl, t, (), {}, True)
+        eq_(
+            len(
+                [
+                    c
+                    for c in impl.unnamed_constraints
+                    if isinstance(c, CheckConstraint)
+                ]
+            ),
+            0,
         )
 
     def test_add_ck_unnamed(self):


### PR DESCRIPTION
Fixes #1846.

Batch recreate still cannot round-trip unnamed reflected CHECK constraints, because they cannot be distinguished from type-bound Boolean/Enum checks. That skip used to be silent, so a constraint could disappear with no signal.

Emit a UserWarning that names the table (and the constraint SQL when available) and points at naming the constraint or restating it via `table_args`.
