### PR TITLE
Use ForeignKey target accessors instead of splitting colspecs

### DIFF
--- a/alembic/autogenerate/render.py
+++ b/alembic/autogenerate/render.py
@@ -1038,14 +1038,12 @@ def _fk_colspec(
     won't fail if the remote table can't be resolved.
 
     """
-    colspec = fk._get_colspec()
-    tokens = colspec.split(".")
-    tname, colname = tokens[-2:]
+    schema, tname, colname, table_key = sqla_compat._fk_target_info(fk)
 
-    if metadata_schema is not None and len(tokens) == 2:
+    if metadata_schema is not None and schema is None:
         table_fullname = "%s.%s" % (metadata_schema, tname)
     else:
-        table_fullname = ".".join(tokens[0:-1])
+        table_fullname = table_key
 
     if (
         not fk.link_to_name

--- a/alembic/operations/batch.py
+++ b/alembic/operations/batch.py
@@ -26,6 +26,7 @@ from ..util.sqla_compat import _copy
 from ..util.sqla_compat import _copy_expression
 from ..util.sqla_compat import _ensure_scope_for_ddl
 from ..util.sqla_compat import _fk_is_self_referential
+from ..util.sqla_compat import _fk_target_info
 from ..util.sqla_compat import _idx_table_bound_expressions
 from ..util.sqla_compat import _is_type_bound
 from ..util.sqla_compat import _remove_column_from_collection
@@ -400,26 +401,21 @@ class ApplyBatchImpl:
     def _setup_referent(
         self, metadata: MetaData, constraint: ForeignKeyConstraint
     ) -> None:
-        spec = constraint.elements[0]._get_colspec()
-        parts = spec.split(".")
-        tname = parts[-2]
-        if len(parts) == 3:
-            referent_schema = parts[0]
-        else:
-            referent_schema = None
+        referent_schema, tname, _, table_key = _fk_target_info(
+            constraint.elements[0]
+        )
 
         if tname != self.temp_table_name:
-            key = sql_schema._get_table_key(tname, referent_schema)
 
-            def colspec(elem: Any):
-                return elem._get_colspec()
+            def colname(elem: Any):
+                return _fk_target_info(elem)[2]
 
-            if key in metadata.tables:
-                t = metadata.tables[key]
+            if table_key in metadata.tables:
+                t = metadata.tables[table_key]
                 for elem in constraint.elements:
-                    colname = colspec(elem).split(".")[-1]
-                    if colname not in t.c:
-                        t.append_column(Column(colname, sqltypes.NULLTYPE))
+                    name = colname(elem)
+                    if name is not None and name not in t.c:
+                        t.append_column(Column(name, sqltypes.NULLTYPE))
             else:
                 Table(
                     tname,
@@ -427,8 +423,9 @@ class ApplyBatchImpl:
                     *[
                         Column(n, sqltypes.NULLTYPE)
                         for n in [
-                            colspec(elem).split(".")[-1]
+                            colname(elem)
                             for elem in constraint.elements
+                            if colname(elem) is not None
                         ]
                     ],
                     schema=referent_schema,

--- a/alembic/operations/schemaobj.py
+++ b/alembic/operations/schemaobj.py
@@ -274,12 +274,15 @@ class SchemaObjects:
         ForeignKey.
 
         """
-        if isinstance(fk._colspec, str):
-            table_key, cname = fk._colspec.rsplit(".", 1)
-            sname, tname = self._parse_table_key(table_key)
+        if hasattr(fk, "target_column"):
+            needs_placeholder = fk.target_column is None
+        else:
+            needs_placeholder = isinstance(fk._colspec, str)
+        if needs_placeholder:
+            sname, tname, cname, table_key = sqla_compat._fk_target_info(fk)
             if table_key not in metadata.tables:
                 rel_t = sa_schema.Table(tname, metadata, schema=sname)
             else:
                 rel_t = metadata.tables[table_key]
-            if cname not in rel_t.c:
+            if cname is not None and cname not in rel_t.c:
                 rel_t.append_column(sa_schema.Column(cname, NULLTYPE))

--- a/alembic/util/sqla_compat.py
+++ b/alembic/util/sqla_compat.py
@@ -338,13 +338,33 @@ def _fk_spec(constraint: ForeignKeyConstraint) -> Any:
     )
 
 
+def _fk_target_info(fk: Any) -> tuple[str | None, str, str | None, str]:
+    """Return ``(schema, table_name, column_name, table_key)`` for a ForeignKey.
+
+    Uses SQLAlchemy 2.1's public target accessors when present so names that
+    contain dots are not split incorrectly.
+    """
+    if hasattr(fk, "target_tokens"):
+        tokens = fk.target_tokens
+        return (
+            tokens.schema,
+            tokens.table_name,
+            tokens.column_name,
+            fk.target_table_key,
+        )
+
+    spec = fk._get_colspec()
+    parts = spec.split(".")
+    colname = parts[-1]
+    tname = parts[-2]
+    schema = parts[0] if len(parts) == 3 else None
+    table_key = f"{schema}.{tname}" if schema is not None else tname
+    return schema, tname, colname, table_key
+
+
 def _fk_is_self_referential(constraint: ForeignKeyConstraint) -> bool:
-    spec = constraint.elements[0]._get_colspec()
-    tokens = spec.split(".")
-    tokens.pop(-1)  # colname
-    tablekey = ".".join(tokens)
     assert constraint.parent is not None
-    return tablekey == constraint.parent.key
+    return _fk_target_info(constraint.elements[0])[3] == constraint.parent.key
 
 
 def _is_type_bound(constraint: Constraint) -> bool:

--- a/docs/build/unreleased/1860.rst
+++ b/docs/build/unreleased/1860.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, autogenerate, batch
+    :tickets: 1860
+
+    Foreign key target lookup now uses SQLAlchemy 2.1's public
+    ``ForeignKey`` accessors when available, instead of splitting a dotted
+    colspec string.  Names that contain dots are no longer mis-parsed, and
+    Alembic no longer reads private ``ForeignKey`` attributes for this.


### PR DESCRIPTION
Alembic was splitting ForeignKey._get_colspec() on ".", which cannot tell a dot inside a name from the separator between schema/table/column. SQLAlchemy 2.1 exposes target_tokens / target_table_key / target_column for this.

Wired those in through sqla_compat, with the old split as a fallback on 2.0.

Fixes #1860