### PR TITLE
docs: document SQLite batch migrations with views

### DIFF
--- a/docs/build/batch.rst
+++ b/docs/build/batch.rst
@@ -272,6 +272,19 @@ by a batch migration.  Therefore it may be necessary to manipulate the
 ``PRAGMA FOREIGN KEYS`` setting if a migration seeks to rename a table vs.
 batch migrate it.
 
+.. _batch_referencing_views:
+
+Dealing with Referencing Views
+------------------------------
+
+On SQLite, batch migrations that use the "move and copy" workflow may fail
+when a view references the table being altered.  The workflow temporarily
+drops the original table before renaming the replacement table, and SQLite
+may reject the rename while the view refers to the missing table.
+
+As a workaround, SQLite's ``PRAGMA legacy_alter_table`` setting may be
+temporarily enabled while the replacement table is renamed.
+
 .. _batch_offline_mode:
 
 Working in Offline Mode


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

**This project accepts pull requests only for issues that a maintainer has
marked with the `open for pull requests` label.**

A pull request that doesn't reference such an issue **is closed
automatically**. That isn't a judgment on your change: it's how we settle on
an approach before anyone spends time writing code, and how we keep two
people from doing the same work at once.

The issue you reference has to be:

* in this repository,
* open,
* labeled `open for pull requests`, and
* not already labeled `code review in progress`, which means someone is
  working on it already.

If there's no such issue yet, open one describing the problem or the feature,
including a complete, runnable example, and wait for a maintainer to add the
label. Please don't open a pull request first and ask for the label
afterwards.

### Fixes

Fixes: #1207

### Description

Documents a SQLite limitation when using batch migrations with views that
reference the table being recreated.

During the "move and copy" workflow, the original table is temporarily
dropped before the replacement table is renamed. SQLite may reject the
rename when an existing view still refers to the temporarily missing table.

The documentation also notes that temporarily enabling
`PRAGMA legacy_alter_table` while the replacement table is renamed can be
used as a workaround.

Verification:

- `git diff --check`
- Sphinx documentation build with warnings treated as errors
- Reproduced the failure locally with SQLite 3.53.1
- Verified that temporarily enabling `PRAGMA legacy_alter_table` allows the
  batch migration to complete and leaves the referencing view usable
